### PR TITLE
Bad overflow usage in header resulting in a display bug and indent/outdent buttons on editor

### DIFF
--- a/src/components/Common/Editor/EditorToolbar/index.ts
+++ b/src/components/Common/Editor/EditorToolbar/index.ts
@@ -48,6 +48,20 @@ export const Strike = {
   icon: '<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M5 12h14m-3-5.5A4 2 0 0 0 12 5h-1a3.5 3.5 0 0 0 0 7h2a3.5 3.5 0 0 1 0 7h-1.5a4 2 0 0 1-4-1.5"/></svg>',
 }
 
+export const Indent = {
+  name: 'indent',
+  tipPosition: 'e',
+  className: 'right',
+  icon: '<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M20 6H9m11 6h-7m7 6H9M4 8l4 4l-4 4"/></svg>',
+}
+
+export const Outdent = {
+  name: 'outdent',
+  tipPosition: 'e',
+  className: 'right',
+  icon: '<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M20 6h-7m7 6h-9m9 6h-7M8 8l-4 4l4 4"/></svg>',
+}
+
 export const Link = {
   name: 'link',
   tipPosition: 'e',
@@ -156,6 +170,8 @@ export const ToolbarMobile = [
   Bold,
   Italic,
   Strike,
+  Indent,
+  Outdent,
   Link,
   List,
   OrderedList,

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -97,7 +97,7 @@ export const CommonLayout = observer(({
         style={{ width: isPc ? `calc(100% - ${base.sideBarWidth}px)` : '100%' }}
         className={`flex transition-all duration-300 overflow-y-hidden w-full flex-col gap-y-1 bg-sencondbackground`}>
         {/* nav bar  */}
-        <header className="relative flex md:h-16 md:min-h-16 h-14 min-h-14 items-center justify-between gap-2 rounded-medium px-2 md:px:4 pt-2 md:pb-2 overflow-x-hidden">
+        <header className="relative flex md:h-16 md:min-h-16 h-14 min-h-14 items-center justify-between gap-2 rounded-medium px-2 md:px:4 pt-2 md:pb-2 overflow-hidden">
           <div className="hidden md:block absolute bottom-[20%] right-[5%] z-[0] h-[350px] w-[350px] overflow-hidden blur-3xl ">
             <div className="w-full h-[100%] bg-[#9936e6] opacity-20"
               style={{ "clipPath": "circle(50% at 50% 50%)" }} />


### PR DESCRIPTION
Proposed correction for bad overflow usage in header resulting in a display bug on safari, and an unwanted scroll bar appearance on Safari and chrome, https://github.com/blinko-space/blinko/issues/407

Also proposal for adding indent and outdent button on mobile in response to https://github.com/blinko-space/blinko/issues/400