### PR TITLE
fix 397: After adding tags to multi-select notes, all the notes become flash thoughts

### DIFF
--- a/src/server/routers/tag.ts
+++ b/src/server/routers/tag.ts
@@ -38,7 +38,7 @@ export const tagRouter = router({
       const notes = await prisma.notes.findMany({ where: { id: { in: ids } } })
       for (const note of notes) {
         const newContent = note.content += ' #' + tag
-        await userCaller(ctx).notes.upsert({ content: newContent, id: note.id })
+        await userCaller(ctx).notes.upsert({ content: newContent, id: note.id, type: -1 })
       }
       return true
     }),


### PR DESCRIPTION
because notes.upsert `input z.object({ ..., type: z.union([z.nativeEnum(NoteType), z.literal(-1)]).default(0),  })`
type default set to 0 when !type.