### PR TITLE
Fix #417 the maximum width status of the home page being saved

### DIFF
--- a/src/components/BlinkoSettings/PerferSetting.tsx
+++ b/src/components/BlinkoSettings/PerferSetting.tsx
@@ -24,8 +24,9 @@ export const PerferSetting = observer(() => {
 
   useEffect(() => {
     setTextLength(blinko.config.value?.textFoldLength?.toString() || '500');
+    setMaxHomePageWidth(blinko.config.value?.maxHomePageWidth?.toString() || '0');
     setCustomBackgroundUrl(blinko.config.value?.customBackgroundUrl || '');
-  }, [blinko.config.value?.textFoldLength]);
+  }, [blinko.config.value?.textFoldLength, blinko.config.value?.maxHomePageWidth]);
 
 
   return <CollapsibleCard


### PR DESCRIPTION
Fix #417 bug, update PerferSetting to include maxHomePageWidth in useEffect dependencies