### PR TITLE
enhancement 390 When tagging an article with ai, it is automatically selected as the tag post.

### DIFF
--- a/src/components/BlinkoAi/aiTag.tsx
+++ b/src/components/BlinkoAi/aiTag.tsx
@@ -18,7 +18,7 @@ export const AiTag: React.FC<AiTagProps> = ({
   confirmText = "Confirm",
 }) => {
   const [selected, setSelected] = React.useState<string[]>(defaultSelected);
-  const [isInsertBefore, setIsInsertBefore] = React.useState(true);
+  const [isInsertBefore, setIsInsertBefore] = React.useState(false);
   const { t } = useTranslation()
   const handleConfirm = () => {
     onSelect(selected, isInsertBefore);


### PR DESCRIPTION
enhancement: #390 change default state of isInsertBefore to false in AiTag component