### PR TITLE
fix #430 Chat history persisting between different user accounts

### DIFF
--- a/src/store/aiStore.tsx
+++ b/src/store/aiStore.tsx
@@ -30,6 +30,9 @@ export class AiStore implements Store {
   sid = 'AiStore';
   constructor() {
     makeAutoObservable(this)
+    eventBus.on('user:signout', () => {
+      this.clear()
+    })
   }
   noteContent = '';
   aiSearchText = '';
@@ -271,5 +274,10 @@ export class AiStore implements Store {
     this.abortController = new AbortController()
     this.isLoading = false
     this.isAnswering = false
+  }
+
+  private clear() {
+    console.log(new Date().toLocaleString(), "aiStore.tsx clear() >>>>")
+    this.chatHistory.clear()
   }
 }

--- a/src/store/blinkoStore.tsx
+++ b/src/store/blinkoStore.tsx
@@ -378,6 +378,12 @@ export class BlinkoStore implements Store {
     this.dailyReviewNoteList.call()
   }
 
+  private clear() {
+    console.log(new Date().toLocaleString(), "blinkoStore.tsx clear() >>>>")
+    this.createContentStorage.clear()
+    this.editContentStorage.clear()
+  }
+
   use() {
     useEffect(() => {
       this.firstLoad()
@@ -448,5 +454,8 @@ export class BlinkoStore implements Store {
 
   constructor() {
     makeAutoObservable(this)
+    eventBus.on('user:signout', () => {
+      this.clear()
+    })
   }
 }


### PR DESCRIPTION
fix #430 Chat history persisting between different user accounts
1. AiStore eventBus.on('user:singout', do clear)
2. BlinkoStore clear tmp edit info 