### PR TITLE
fix #444 Editing a ‘Note’ that’s selected when viewing by tag changes the note to a Blinko

### DIFF
--- a/src/components/BlinkoEditor/index.tsx
+++ b/src/components/BlinkoEditor/index.tsx
@@ -105,10 +105,10 @@ export const BlinkoEditor = observer(({ mode, onSended, onHeightChange, isInDial
         isCreateMode ? <div className='text-xs text-ignore ml-2'>Drop to upload files</div> :
           <div className='text-xs text-desc'>{dayjs(blinko.curSelectedNote!.createdAt).format("YYYY-MM-DD hh:mm:ss")}</div>
       }
-      onSend={async ({ files, references }) => {
+      onSend={async ({ files, references, noteType }) => {
         if (isCreateMode) {
           //@ts-ignore
-          await blinko.upsertNote.call({ references, refresh: false, content: blinko.noteContent, attachments: files.map(i => { return { name: i.name, path: i.uploadPath, size: i.size, type: i.type } }) })
+          await blinko.upsertNote.call({ type: noteType, references, refresh: false, content: blinko.noteContent, attachments: files.map(i => { return { name: i.name, path: i.uploadPath, size: i.size, type: i.type } }) })
           blinko.createAttachmentsStorage.clear()
           blinko.createContentStorage.clear()
           if (blinko.noteTypeDefault == NoteType.NOTE && router.pathname != '/notes') {
@@ -124,6 +124,7 @@ export const BlinkoEditor = observer(({ mode, onSended, onHeightChange, isInDial
           console.log(files.map(i => { return { name: i.name, path: i.uploadPath, size: i.size } }))
           await blinko.upsertNote.call({
             id: blinko.curSelectedNote!.id,
+            type: noteType,
             //@ts-ignore
             content: blinko.curSelectedNote.content,
             //@ts-ignore

--- a/src/components/Common/Editor/Toolbar/NoteTypeButton/index.tsx
+++ b/src/components/Common/Editor/Toolbar/NoteTypeButton/index.tsx
@@ -4,22 +4,32 @@ import { NoteType } from '@/server/types';
 import { BlinkoStore } from '@/store/blinkoStore';
 import { RootStore } from '@/store';
 import { Div } from '@/components/Common/Div';
+import { useEffect, useState } from 'react';
 
-export const NoteTypeButton = () => {
+export const NoteTypeButton = ({ noteType, setNoteType}: {
+  noteType: NoteType,
+  setNoteType: (noteType: NoteType) => void
+}) => {
   const { t } = useTranslation();
-  const blinko = RootStore.Get(BlinkoStore);
+  const [type, setType] = useState(noteType);
 
+  useEffect(() => {
+    setType(noteType);
+  }, [noteType]);
+  
   return (
     <Div
       onTap={() => {
-        blinko.noteTypeDefault = blinko.noteTypeDefault == NoteType.BLINKO ? NoteType.NOTE : NoteType.BLINKO;
+        const newType = type == NoteType.BLINKO ? NoteType.NOTE : NoteType.BLINKO;
+        setType(newType);
+        setNoteType(newType);
       }}>
       <IconButton
-        icon={blinko.noteTypeDefault == NoteType.BLINKO ? 'basil:lightning-solid' : 'solar:notes-minimalistic-bold-duotone'}
+        icon={type == NoteType.BLINKO ? 'basil:lightning-solid' : 'solar:notes-minimalistic-bold-duotone'}
         classNames={{
-          icon: blinko.noteTypeDefault == NoteType.BLINKO ? 'text-[#FFD700]' : 'text-[#3B82F6]'
+          icon: type == NoteType.BLINKO ? 'text-[#FFD700]' : 'text-[#3B82F6]'
         }}
-        tooltip={blinko.noteTypeDefault == NoteType.BLINKO ? t('blinko') : t('note')}
+        tooltip={type == NoteType.BLINKO ? t('blinko') : t('note')}
       />
     </Div>
 

--- a/src/components/Common/Editor/editorStore.tsx
+++ b/src/components/Common/Editor/editorStore.tsx
@@ -15,6 +15,7 @@ import { DialogStandaloneStore } from '@/store/module/DialogStandalone';
 import { Button } from '@nextui-org/react';
 import axios from 'axios';
 import { ToastPlugin } from '@/store/module/Toast/Toast';
+import { NoteType } from '@/server/types';
 
 export class EditorStore {
   files: FileType[] = []
@@ -32,6 +33,7 @@ export class EditorStore {
   isShowSearch: boolean = false
   onSend: (args: OnSendContentType) => Promise<any>
   isFullscreen: boolean = false;
+  noteType: NoteType;
 
   get showIsEditText() {
     if (this.mode == 'edit') {
@@ -297,6 +299,7 @@ export class EditorStore {
       await this.onSend?.({
         content: this.vditor?.getValue() ?? '',
         files: this.files.map(i => ({ ...i, uploadPath: i.uploadPromise.value })),
+        noteType: this.noteType,
         references: this.references
       });
       this.clearEditor();

--- a/src/components/Common/Editor/hooks/useEditor.ts
+++ b/src/components/Common/Editor/hooks/useEditor.ts
@@ -267,5 +267,5 @@ export const useEditorHeight = (
 ) => {
   useEffect(() => {
     onHeightChange?.();
-  }, [blinko.noteTypeDefault, content, store.files?.length, store.viewMode]);
+  }, [store.noteType, content, store.files?.length, store.viewMode]);
 }; 

--- a/src/components/Common/Editor/index.tsx
+++ b/src/components/Common/Editor/index.tsx
@@ -10,7 +10,7 @@ import { BlinkoStore } from '@/store/blinkoStore';
 import { _ } from '@/lib/lodash';
 import { useTranslation } from 'react-i18next';
 import { useMediaQuery } from 'usehooks-ts';
-import { type Attachment } from '@/server/types';
+import { toNoteTypeEnum, type Attachment } from '@/server/types';
 import { Card } from '@nextui-org/react';
 import { AttachmentsRender, ReferenceRender } from '../AttachmentRender';
 import { UploadButtons } from './Toolbar/UploadButtons';
@@ -51,6 +51,7 @@ const Editor = observer(({ content, onChange, onSend, isSendLoading, originFiles
   const blinko = RootStore.Get(BlinkoStore)
   const { t } = useTranslation()
 
+  store.noteType = mode === 'create' ? blinko.noteTypeDefault : toNoteTypeEnum(blinko.curSelectedNote?.type);
   useEditorInit(store, onChange, onSend, mode, originReference, content);
   useEditorEvents(store);
   useEditorFiles(store, blinko, originFiles);
@@ -114,7 +115,10 @@ const Editor = observer(({ content, onChange, onSend, isSendLoading, originFiles
         <div className='flex w-full items-center gap-1 mt-auto'>
           {!hiddenToolbar && (
             <>
-              <NoteTypeButton />
+              <NoteTypeButton
+                noteType={store.noteType}
+                setNoteType={(noteType) => store.noteType = noteType}
+              />
               <HashtagButton store={store} content={content} />
               <ReferenceButton store={store} />
               <AIWriteButton store={store} content={content} />

--- a/src/components/Common/Editor/type.ts
+++ b/src/components/Common/Editor/type.ts
@@ -1,8 +1,10 @@
+import { NoteType } from "@/server/types";
 import { PromiseState } from "@/store/standard/PromiseState";
 
 export type OnSendContentType = {
   content: string;
   files: (FileType & { uploadPath: string })[]
+  noteType: NoteType;
   references: number[]
 }
 

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -12,6 +12,16 @@ export enum NoteType {
   'BLINKO',
   'NOTE'
 }
+export function toNoteTypeEnum(v?: number, fallback: NoteType = NoteType.BLINKO): NoteType {
+  switch (v) {
+    case 0:
+      return NoteType.BLINKO;
+    case 1:
+      return NoteType.NOTE;
+    default:
+      return fallback;
+  }
+}
 
 export const ZUserPerferConfigKey = z.union([
   z.literal('textFoldLength'),


### PR DESCRIPTION
fix #444  Refactor: decouple `noteType`  move to the Editor initialization.

