### PR TITLE
fix(ai): Preserve original updatedAt timestamp during memos import and reindexing

### DIFF
--- a/src/server/plugins/ai.ts
+++ b/src/server/plugins/ai.ts
@@ -83,7 +83,7 @@ export class AiService {
     }
   }
 
-  static async embeddingUpsert({ id, content, type, createTime }: { id: number, content: string, type: 'update' | 'insert', createTime: Date }) {
+  static async embeddingUpsert({ id, content, type, createTime, updatedAt }: { id: number, content: string, type: 'update' | 'insert', createTime: Date, updatedAt?: Date }) {
     try {
       const { VectorStore, MarkdownSplitter } = await AiModelFactory.GetProvider()
       const config = await AiModelFactory.globalConfig()
@@ -111,8 +111,10 @@ export class AiService {
           data: {
             metadata: {
               isIndexed: true
-            }
-          }
+            },
+            updatedAt,
+          },
+        
         })
       } catch (error) {
         console.log(error)
@@ -244,6 +246,7 @@ export class AiService {
           if (note?.content != '') {
             const { ok, error } = await AiService.embeddingUpsert({
               createTime: note.createdAt,
+              updatedAt: note.updatedAt,
               id: note?.id,
               content: note?.content,
               type: 'update' as const

--- a/src/server/plugins/ai.ts
+++ b/src/server/plugins/ai.ts
@@ -133,7 +133,7 @@ export class AiService {
   }
 
   //api/file/123.pdf
-  static async embeddingInsertAttachments({ id, filePath }: { id: number, filePath: string }) {
+  static async embeddingInsertAttachments({ id, updatedAt, filePath }: { id: number, updatedAt?: Date, filePath: string }) {
     try {
       // const note = await prisma.notes.findUnique({ where: { id } })
       // //@ts-ignore
@@ -161,7 +161,8 @@ export class AiService {
             metadata: {
               isIndexed: true,
               isAttachmentsIndexed: true
-            }
+            },
+            updatedAt
           }
         })
       } catch (error) {
@@ -266,12 +267,11 @@ export class AiService {
               };
             }
           }
-          //@ts-ignore
           if (note?.attachments) {
-            //@ts-ignore
-            for (const attachment of note?.attachments) {
+            for (const attachment of note.attachments) {
               const { ok, error } = await AiService.embeddingInsertAttachments({
-                id: note?.id,
+                id: note.id,
+                updatedAt: note.updatedAt,
                 filePath: attachment?.path
               });
               if (ok) {

--- a/src/server/plugins/memos.ts
+++ b/src/server/plugins/memos.ts
@@ -55,16 +55,11 @@ export class Memos {
 
         const note = await userCaller(ctx).notes.upsert({
           content: row?.content,
+          createdAt: new Date(row!.created_ts * 1000),
+          updatedAt: new Date(row!.updated_ts * 1000),
         });
 
         if (note) {
-          await prisma.notes.update({
-            where: { id: note.id },
-            data: {
-              createdAt: new Date(row!.created_ts * 1000),
-              updatedAt: new Date(row!.updated_ts * 1000),
-            }
-          });
           yield {
             type: 'success',
             content: note.content.slice(0, 30),

--- a/src/server/routers/note.ts
+++ b/src/server/routers/note.ts
@@ -701,7 +701,7 @@ export const noteRouter = router({
         if (config?.isUseAI) {
           AiService.embeddingUpsert({ id: note.id, content: note.content, type: 'update', createTime: note.createdAt!, updatedAt: note.updatedAt })
           for (const attachment of attachments) {
-            AiService.embeddingInsertAttachments({ id: note.id, filePath: attachment.path })
+            AiService.embeddingInsertAttachments({ id: note.id, updatedAt: note.updatedAt, filePath: attachment.path })
           }
         }
         SendWebhook({ ...note, attachments }, isRecycle ? 'delete' : 'update', ctx)
@@ -734,7 +734,7 @@ export const noteRouter = router({
           if (config?.isUseAI) {
             AiService.embeddingUpsert({ id: note.id, content: note.content, type: 'insert', createTime: note.createdAt!, updatedAt: note.updatedAt })
             for (const attachment of attachments) {
-              AiService.embeddingInsertAttachments({ id: note.id, filePath: attachment.path })
+              AiService.embeddingInsertAttachments({ id: note.id, updatedAt: note.updatedAt, filePath: attachment.path })
             }
           }
           return note

--- a/src/server/routers/note.ts
+++ b/src/server/routers/note.ts
@@ -699,7 +699,7 @@ export const noteRouter = router({
         }
 
         if (config?.isUseAI) {
-          AiService.embeddingUpsert({ id: note.id, content: note.content, type: 'update', createTime: note.createdAt! })
+          AiService.embeddingUpsert({ id: note.id, content: note.content, type: 'update', createTime: note.createdAt!, updatedAt: note.updatedAt })
           for (const attachment of attachments) {
             AiService.embeddingInsertAttachments({ id: note.id, filePath: attachment.path })
           }
@@ -732,7 +732,7 @@ export const noteRouter = router({
           SendWebhook({ ...note, attachments }, 'create', ctx)
 
           if (config?.isUseAI) {
-            AiService.embeddingUpsert({ id: note.id, content: note.content, type: 'insert', createTime: note.createdAt! })
+            AiService.embeddingUpsert({ id: note.id, content: note.content, type: 'insert', createTime: note.createdAt!, updatedAt: note.updatedAt })
             for (const attachment of attachments) {
               AiService.embeddingInsertAttachments({ id: note.id, filePath: attachment.path })
             }


### PR DESCRIPTION
Currently, when AI is enabled, the time of notes imported from memos is changed to the current time. Rebuilding the index will also cause the time of notes to change to the current time. I think this may be a mistake, because the update time of the note should not be refreshed when the content of the note has not changed.

This PR solves this problem by simply and crudely re-assigning updatedAt, because I assume that updatedAt is only used to display on the user interface. If the updatedAt field doesn't just represent when the note content was updated, then maybe we need to add another field to disambiguate it.

_I've proceeded with this implementation to facilitate my data migration during the holiday period. I apologize for not initiating a discussion beforehand, but I believe this fix addresses an immediate need while maintaining the system's integrity._