### PR TITLE
fix(note): FE accidentally turned into blinko after operating on note

### DIFF
--- a/src/server/routers/note.ts
+++ b/src/server/routers/note.ts
@@ -542,7 +542,7 @@ export const noteRouter = router({
     })
     .input(z.object({
       content: z.union([z.string(), z.null()]).default(null),
-      type: z.union([z.nativeEnum(NoteType), z.literal(-1)]).default(0),
+      type: z.union([z.nativeEnum(NoteType), z.literal(-1)]).default(-1),
       attachments: z.array(z.object({
         name: z.string(),
         path: z.string(),

--- a/src/store/blinkoStore.tsx
+++ b/src/store/blinkoStore.tsx
@@ -135,7 +135,7 @@ export class BlinkoStore implements Store {
         content = null,
         isArchived,
         isRecycle,
-        type = this.noteTypeDefault,
+        type,
         id,
         attachments = [],
         refresh = true,


### PR DESCRIPTION
<img width="1117" alt="image" src="https://github.com/user-attachments/assets/2858d205-d749-40af-bf19-671722045178" />

<img width="497" alt="image" src="https://github.com/user-attachments/assets/5d89d018-a4f1-41fb-8a02-a220b5cbf9a0" />



For highlighted operations on blinkos or notes, the corresponding `note.type` in the database would be assigned `0`, causing notes to unexpectedly become `BLINKO`.

This PR fixes the issue by adjusting default values for frontend/backend _upsertNote_ operations. I've verified this PR by checking all interfaces that call the upsert method wherever possible - it should work properly. 

I'm not sure if this modification conflicts with your original intentions, so please feel free to handle this PR as you see fit.