### PR TITLE
Fix(server/config)  custom background url not work

### DIFF
--- a/src/server/routers/config.ts
+++ b/src/server/routers/config.ts
@@ -20,6 +20,7 @@ export const getGlobalConfig = async ({ ctx, useAdmin = false }: { ctx?: Context
       || item.key == 'themeColor'
       || item.key == 'themeForegroundColor'
       || item.key == 'maxHomePageWidth'
+      || item.key == 'customBackgroundUrl'
     ) {
       acc[item.key] = config.value;
       return acc;


### PR DESCRIPTION
<img width="741" alt="image" src="https://github.com/user-attachments/assets/d7fabe09-1669-4c97-bbb8-0017a54b0c72" />

This PR just exposes 'customBackgroundUrl' from trpc.config.list to achieve the effect described in the documentation.