### PR TITLE
fix(plugin-manager): correct plugin setting panel flag assignment

### DIFF
--- a/src/store/plugin/pluginManagerStore.ts
+++ b/src/store/plugin/pluginManagerStore.ts
@@ -219,7 +219,7 @@ export class PluginManagerStore implements Store {
       plugin.init();
       this.plugins.set(plugin.name, plugin);
       if (plugin.withSettingPanel) {
-        this.plugins[plugin.name].withSettingPanel = true;
+        this.plugins.get(plugin.name)!.withSettingPanel = true;
       }
       return plugin;
     } catch (error) {


### PR DESCRIPTION
A very small fix that wiped out a reported error.

However, I feel as though the part of the code that was changed doesn't seem to be of much use if it's not dealing with a special case.

https://github.com/blinko-space/blinko/commit/0e841613878451124469c3cbef133a0e33de2d60#diff-1ebd9ecac7133ad8e4e7bbc8d483d0482224b0991ca7e431dc1bce755f61d1bbL221-L223