### PR TITLE
fix: delete tags and botes button undelete tags Issue || fix: delete tags and bottles button undelete tags Issue

### DIFF
--- a/src/server/routers/tag.ts
+++ b/src/server/routers/tag.ts
@@ -218,6 +218,7 @@ export const tagRouter = router({
       const tag = await prisma.tag.findFirst({ where: { id, accountId: Number(ctx.id) }, include: { tagsToNote: true } })
       const allNotesId = tag?.tagsToNote.map(i => i.noteId) ?? []
       await userCaller(ctx).notes.trashMany({ ids: allNotesId })
+      await userCaller(ctx).tags.deleteOnlyTag({ id })
       return true
     }),
   updateTagOrder: authProcedure


### PR DESCRIPTION

目前点击删除标签和笔记按钮，仅会将标签下的内容放入回收站，但并未删除标签。
---
Currently clicking on the delete tab and notes button only puts the contents of the tab into the recycle bin, but does not delete the tab.
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
Currently clicking the Delete Tags and Notes button will only place the content under the tags into the Recycle Bin, but the tags are not deleted.
---
Currently clicking on the delete tab and notes button only puts the contents of the tab into the recycle bin, but does not delete the tab.
