### PR TITLE
fix: decode filename from binary to UTF-8 in file upload

### DIFF
--- a/app/api/file/upload/route.ts
+++ b/app/api/file/upload/route.ts
@@ -42,6 +42,7 @@ export const POST = async (req: NextRequest) => {
         if (fieldname === 'file') {
           const passThrough = new PassThrough();
           let fileSize = 0;
+          const decodedFilename = Buffer.from(info.filename, 'binary').toString('utf-8');
           
           stream.on('data', (chunk) => {
             fileSize += chunk.length;
@@ -52,7 +53,7 @@ export const POST = async (req: NextRequest) => {
             passThrough.end();
             fileInfo = {
               stream: passThrough,
-              filename: info.filename.replaceAll(" ", "_"),
+              filename: decodedFilename.replaceAll(" ", "_"),
               mimeType: info.mimeType,
               size: fileSize
             };


### PR DESCRIPTION
中文文件名不会出现乱码的情况
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
There will be no garbled Chinese file name
