### PR TITLE
fix: conditionally render button based on daily review configuration

### DIFF
--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -151,7 +151,7 @@ export const CommonLayout = observer(({ children, header }: { children?: React.R
               <div className="flex items-center justify-center gap-2 md:gap-4 w-auto ">
                 <BarSearchInput isPc={isPc} />
                 <FilterPop />
-                <Badge size="sm" className="shrink-0" content={blinkoStore.dailyReviewNoteList.value?.length} color="warning">
+                {!blinkoStore.config.value?.isCloseDailyReview && <Badge size="sm" className="shrink-0" content={blinkoStore.dailyReviewNoteList.value?.length} color="warning">
                   <Link href="/review" passHref legacyBehavior>
                     <Button
                       as="a"
@@ -163,7 +163,7 @@ export const CommonLayout = observer(({ children, header }: { children?: React.R
                       <Icon className="cursor-pointer" icon="tabler:bulb" width="24" height="24" />
                     </Button>
                   </Link>
-                </Badge>
+                </Badge>}
                 <BlinkoNotification />
               </div>
             </div>


### PR DESCRIPTION
当前版本将”关闭每日回顾“开启后，依然会显示每日回顾的入口，原因是前端未根据配置信息控制入口button的显示
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
The current version will "Close Daily Review" after the "Daily Review" is turned on, the entrance for the daily review will still be displayed, because the front-end does not control the display of the entrance button based on the configuration information
