### PR TITLE
feat(BlinkoAddButton): When the H5 bottom bar appears, move the bottom up slightly to avoid being obscured.

### DIFF
--- a/src/components/BlinkoAddButton/index.tsx
+++ b/src/components/BlinkoAddButton/index.tsx
@@ -2,6 +2,7 @@
 import { useState, useRef, TouchEvent } from 'react';
 import { motion } from 'motion/react';
 import { Icon } from '@/components/Common/Iconify/icons';
+import { useSwiper } from "@/lib/hooks";
 import { observer } from 'mobx-react-lite';
 import { useMediaQuery } from 'usehooks-ts';
 import { ShowEditBlinkoModel } from '../BlinkoRightClickMenu';
@@ -29,6 +30,7 @@ export const BlinkoAddButton = observer(() => {
   const [activeButton, setActiveButton] = useState<'none' | 'top' | 'bottom'>('none');
   const isPc = useMediaQuery('(min-width: 768px)');
   const router = useRouter()
+  const isVisible = useSwiper()
 
   // Add touch-related states
   const touchStartRef = useRef({ x: 0, y: 0 });
@@ -127,7 +129,7 @@ export const BlinkoAddButton = observer(() => {
     height: BUTTON_SIZE.CENTER,
     position: 'fixed',
     right: 40,
-    bottom: 110,
+    bottom: isVisible ? 140 : 110,
     zIndex: 50
   }}>
     {/* Writing icon button (Top) */}


### PR DESCRIPTION
当H5 底部 bar 出来时，让 bottom 往上挪一点，避免被遮挡

When the H5 bottom bar appears, move the bottom up slightly to avoid being obscured.
***
![image](https://github.com/user-attachments/assets/16112ddb-fd34-4bd2-8ddf-d6faa6ce5255)
![image](https://github.com/user-attachments/assets/7de1b3fb-78c4-411d-b3a3-aabe49e500ce)
![image](https://github.com/user-attachments/assets/8a87b9c5-aa64-4c1e-8979-5ee2ba60496d)
