### PR TITLE
Update docker-compose.prod.yml

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,7 +11,7 @@ services:
       # NEXTAUTH_URL: http://localhost:1111
       # NEXT_PUBLIC_BASE_URL: http://localhost:1111
       NEXTAUTH_SECRET: my_ultra_secure_nextauth_secret
-      DATABASE_URL: postgresql://postgres:mysecretpassword@postgres:5432/postgres
+      DATABASE_URL: postgresql://postgres:mysecretpassword@blinko-postgres:5432/postgres
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Updating blinko to latest version 1.2.3 using the docker-compose file fails to start the application. This commit fixes the problem.