### PR TITLE
don't expose postgreSQL container to internet

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,8 +38,8 @@ services:
     image: postgres:14
     container_name: blinko-postgres
     restart: always
-    ports:
-      - 5432:5432
+    # ports:
+    #  - 5432:5432
     environment:
       POSTGRES_DB: postgres
       POSTGRES_USER: postgres

--- a/install.sh
+++ b/install.sh
@@ -28,7 +28,6 @@ else
     docker run -d \
       --name blinko-postgres \
       --network blinko-network \
-      -p 5435:5432 \
       -e POSTGRES_DB=postgres \
       -e POSTGRES_USER=postgres \
       -e POSTGRES_PASSWORD=mysecretpassword \


### PR DESCRIPTION
Both containers are already correctly defined to reside in same `blinko-network` so they can communicate just fine, the `ports` item is not required and it will in fact expose the PSQL server to the internet.
This PR simply unexpose the PSQL server so it stays internal to the blinko-network.
