### PR TITLE
✨ Added access to Ollama cloud API by providing the authorization header

### DIFF
--- a/server/aiServer/providers/EmbeddingProvider.ts
+++ b/server/aiServer/providers/EmbeddingProvider.ts
@@ -45,7 +45,8 @@ export class EmbeddingProvider extends BaseProvider {
       case 'ollama':
         return createOllama({
           baseURL: config.baseURL?.trim() || undefined,
-          fetch: this.proxiedFetch
+          fetch: this.proxiedFetch,
+          headers: config.apiKey?.trim() ? { 'Authorization': `Bearer ${config.apiKey.trim()}`} : undefined
         }).textEmbeddingModel(config.modelKey);
 
       case 'custom':


### PR DESCRIPTION
Ollama provide cloud model since September.
https://ollama.com/blog/cloud-models
https://docs.ollama.com/cloud#generating-a-response

I added the Authorization with api key in headers if it is not empty.