### PR TITLE
fix: update note type assignment in updateBlinkoTool

### DIFF
--- a/server/aiServer/tools/updateBlinko.ts
+++ b/server/aiServer/tools/updateBlinko.ts
@@ -49,7 +49,7 @@ export const updateBlinkoTool = createTool({
       })
       return await caller.notes.upsert({
         content: context.content,
-        type: typeStr,
+        type: noteType,
         id: context.id
       })
     } catch (error) {


### PR DESCRIPTION
This pull request fiyes the `updateBlinkoTool` logic, ensuring that the correct variable (`noteType`) is used when upserting notes instead of the previous `typeStr`. 