### PR TITLE
feat: Move AI provider model fetching to server-side for Docker network compatibility

### DIFF
--- a/app/src/components/BlinkoSettings/AiSetting/constants.tsx
+++ b/app/src/components/BlinkoSettings/AiSetting/constants.tsx
@@ -1,5 +1,7 @@
 import { Icon } from '@/components/Common/Iconify/icons';
 import { ModelCapabilities } from '@server/aiServer/types';
+// Re-export from shared module for backward compatibility
+export { ModelTemplate, DEFAULT_MODEL_TEMPLATES, inferModelCapabilities } from '@shared/lib/modelTemplates';
 
 export const CAPABILITY_ICONS = {
   inference: <Icon icon="hugeicons:chat" width="16" height="16" />,
@@ -33,15 +35,6 @@ export const CAPABILITY_COLORS = {
   embedding: 'warning',
   rerank: 'secondary'
 } as const;
-
-export interface ModelTemplate {
-  modelKey: string;
-  title: string;
-  capabilities: Partial<ModelCapabilities>;
-  config?: {
-    embeddingDimensions?: number;
-  };
-}
 
 export const PROVIDER_TEMPLATES = [
   {
@@ -144,149 +137,4 @@ export const PROVIDER_TEMPLATES = [
     icon: 'voyageai',
     description: 'High-quality embedding models for retrieval and search'
   }
-];
-
-export const DEFAULT_MODEL_TEMPLATES: ModelTemplate[] = [
-  // OpenAI Models
-  { modelKey: 'gpt-4o', title: 'GPT-4o', capabilities: { inference: true, tools: true, image: true } },
-  { modelKey: 'gpt-4o-mini', title: 'GPT-4o Mini', capabilities: { inference: true, tools: true, image: true } },
-  { modelKey: 'gpt-4-turbo', title: 'GPT-4 Turbo', capabilities: { inference: true, tools: true, image: true } },
-  { modelKey: 'gpt-4-turbo-preview', title: 'GPT-4 Turbo Preview', capabilities: { inference: true, tools: true } },
-  { modelKey: 'gpt-4', title: 'GPT-4', capabilities: { inference: true, tools: true } },
-  { modelKey: 'gpt-4-vision-preview', title: 'GPT-4 Vision Preview', capabilities: { inference: true, image: true } },
-  { modelKey: 'gpt-3.5-turbo', title: 'GPT-3.5 Turbo', capabilities: { inference: true, tools: true } },
-  { modelKey: 'gpt-3.5-turbo-instruct', title: 'GPT-3.5 Turbo Instruct', capabilities: { inference: true } },
-  { modelKey: 'text-embedding-3-large', title: 'Text Embedding 3 Large', capabilities: { embedding: true }, config: { embeddingDimensions: 3072 } },
-  { modelKey: 'text-embedding-3-small', title: 'Text Embedding 3 Small', capabilities: { embedding: true }, config: { embeddingDimensions: 1536 } },
-  { modelKey: 'text-embedding-ada-002', title: 'Text Embedding Ada 002', capabilities: { embedding: true }, config: { embeddingDimensions: 1536 } },
-  { modelKey: 'dall-e-3', title: 'DALL-E 3', capabilities: { imageGeneration: true } },
-  { modelKey: 'dall-e-2', title: 'DALL-E 2', capabilities: { imageGeneration: true } },
-  { modelKey: 'tts-1', title: 'TTS 1', capabilities: { audio: true } },
-  { modelKey: 'tts-1-hd', title: 'TTS 1 HD', capabilities: { audio: true } },
-
-  // Anthropic Models
-  { modelKey: 'claude-3-5-sonnet-20241022', title: 'Claude 3.5 Sonnet', capabilities: { inference: true, tools: true, image: true } },
-  { modelKey: 'claude-3-5-haiku-20241022', title: 'Claude 3.5 Haiku', capabilities: { inference: true, tools: true, image: true } },
-  { modelKey: 'claude-3-opus-20240229', title: 'Claude 3 Opus', capabilities: { inference: true, tools: true, image: true } },
-  { modelKey: 'claude-3-sonnet-20240229', title: 'Claude 3 Sonnet', capabilities: { inference: true, tools: true, image: true } },
-  { modelKey: 'claude-3-haiku-20240307', title: 'Claude 3 Haiku', capabilities: { inference: true, tools: true, image: true } },
-  { modelKey: 'claude-2.1', title: 'Claude 2.1', capabilities: { inference: true } },
-  { modelKey: 'claude-2.0', title: 'Claude 2.0', capabilities: { inference: true } },
-  { modelKey: 'claude-instant-1.2', title: 'Claude Instant 1.2', capabilities: { inference: true } },
-
-  // Google Models
-  { modelKey: 'gemini-1.5-pro', title: 'Gemini 1.5 Pro', capabilities: { inference: true, tools: true, image: true, video: true, audio: true } },
-  { modelKey: 'gemini-1.5-flash', title: 'Gemini 1.5 Flash', capabilities: { inference: true, tools: true, image: true, video: true, audio: true } },
-  { modelKey: 'gemini-pro', title: 'Gemini Pro', capabilities: { inference: true, tools: true } },
-  { modelKey: 'gemini-pro-vision', title: 'Gemini Pro Vision', capabilities: { inference: true, image: true } },
-  { modelKey: 'text-embedding-004', title: 'Text Embedding 004', capabilities: { embedding: true }, config: { embeddingDimensions: 768 } },
-  { modelKey: 'text-embedding-gecko', title: 'Text Embedding Gecko', capabilities: { embedding: true }, config: { embeddingDimensions: 768 } },
-
-  // Meta Llama Models
-  { modelKey: 'llama-3.1-405b-instruct', title: 'Llama 3.1 405B Instruct', capabilities: { inference: true, tools: true } },
-  { modelKey: 'llama-3.1-70b-instruct', title: 'Llama 3.1 70B Instruct', capabilities: { inference: true, tools: true } },
-  { modelKey: 'llama-3.1-8b-instruct', title: 'Llama 3.1 8B Instruct', capabilities: { inference: true, tools: true } },
-  { modelKey: 'llama-3-70b-instruct', title: 'Llama 3 70B Instruct', capabilities: { inference: true, tools: true } },
-  { modelKey: 'llama-3-8b-instruct', title: 'Llama 3 8B Instruct', capabilities: { inference: true, tools: true } },
-  { modelKey: 'llama-2-70b-chat', title: 'Llama 2 70B Chat', capabilities: { inference: true } },
-  { modelKey: 'llama-2-13b-chat', title: 'Llama 2 13B Chat', capabilities: { inference: true } },
-  { modelKey: 'llama-2-7b-chat', title: 'Llama 2 7B Chat', capabilities: { inference: true } },
-
-  // Mistral Models
-  { modelKey: 'mistral-large-2407', title: 'Mistral Large 2407', capabilities: { inference: true, tools: true } },
-  { modelKey: 'mistral-large-2402', title: 'Mistral Large 2402', capabilities: { inference: true, tools: true } },
-  { modelKey: 'mistral-medium', title: 'Mistral Medium', capabilities: { inference: true } },
-  { modelKey: 'mistral-small', title: 'Mistral Small', capabilities: { inference: true } },
-  { modelKey: 'mistral-tiny', title: 'Mistral Tiny', capabilities: { inference: true } },
-  { modelKey: 'mixtral-8x7b-instruct', title: 'Mixtral 8x7B Instruct', capabilities: { inference: true } },
-  { modelKey: 'mixtral-8x22b-instruct', title: 'Mixtral 8x22B Instruct', capabilities: { inference: true } },
-  { modelKey: 'mistral-7b-instruct', title: 'Mistral 7B Instruct', capabilities: { inference: true } },
-
-  // Qwen Models
-  { modelKey: 'qwen2.5-72b-instruct', title: 'Qwen 2.5 72B Instruct', capabilities: { inference: true, tools: true } },
-  { modelKey: 'qwen2.5-32b-instruct', title: 'Qwen 2.5 32B Instruct', capabilities: { inference: true, tools: true } },
-  { modelKey: 'qwen2.5-14b-instruct', title: 'Qwen 2.5 14B Instruct', capabilities: { inference: true, tools: true } },
-  { modelKey: 'qwen2.5-7b-instruct', title: 'Qwen 2.5 7B Instruct', capabilities: { inference: true, tools: true } },
-  { modelKey: 'qwen2-72b-instruct', title: 'Qwen 2 72B Instruct', capabilities: { inference: true, tools: true } },
-  { modelKey: 'qwen2-7b-instruct', title: 'Qwen 2 7B Instruct', capabilities: { inference: true, tools: true } },
-  { modelKey: 'qwen-vl-plus', title: 'Qwen VL Plus', capabilities: { inference: true, image: true } },
-  { modelKey: 'qwen-vl-max', title: 'Qwen VL Max', capabilities: { inference: true, image: true } },
-
-  // DeepSeek Models
-  { modelKey: 'deepseek-chat', title: 'DeepSeek Chat', capabilities: { inference: true, tools: true } },
-  { modelKey: 'deepseek-coder', title: 'DeepSeek Coder', capabilities: { inference: true, tools: true } },
-  { modelKey: 'deepseek-v2.5', title: 'DeepSeek V2.5', capabilities: { inference: true, tools: true } },
-
-  // Yi Models
-  { modelKey: 'yi-large', title: 'Yi Large', capabilities: { inference: true, tools: true } },
-  { modelKey: 'yi-medium', title: 'Yi Medium', capabilities: { inference: true } },
-  { modelKey: 'yi-vision', title: 'Yi Vision', capabilities: { inference: true, image: true } },
-
-  // Cohere Models
-  { modelKey: 'command-r-plus', title: 'Command R+', capabilities: { inference: true, tools: true } },
-  { modelKey: 'command-r', title: 'Command R', capabilities: { inference: true, tools: true } },
-  { modelKey: 'command', title: 'Command', capabilities: { inference: true } },
-  { modelKey: 'command-light', title: 'Command Light', capabilities: { inference: true } },
-  { modelKey: 'embed-english-v3.0', title: 'Embed English v3.0', capabilities: { embedding: true } },
-  { modelKey: 'embed-multilingual-v3.0', title: 'Embed Multilingual v3.0', capabilities: { embedding: true } },
-  { modelKey: 'rerank-english-v3.0', title: 'Rerank English v3.0', capabilities: { rerank: true } },
-  { modelKey: 'rerank-multilingual-v3.0', title: 'Rerank Multilingual v3.0', capabilities: { rerank: true } },
-
-  // Popular Ollama Models
-  { modelKey: 'llama3.1:70b', title: 'Llama 3.1 70B (Ollama)', capabilities: { inference: true, tools: true } },
-  { modelKey: 'llama3.1:8b', title: 'Llama 3.1 8B (Ollama)', capabilities: { inference: true, tools: true } },
-  { modelKey: 'qwen2.5:72b', title: 'Qwen 2.5 72B (Ollama)', capabilities: { inference: true, tools: true } },
-  { modelKey: 'qwen2.5:32b', title: 'Qwen 2.5 32B (Ollama)', capabilities: { inference: true, tools: true } },
-  { modelKey: 'qwen2.5:14b', title: 'Qwen 2.5 14B (Ollama)', capabilities: { inference: true, tools: true } },
-  { modelKey: 'qwen2.5:7b', title: 'Qwen 2.5 7B (Ollama)', capabilities: { inference: true, tools: true } },
-  { modelKey: 'mistral-nemo:12b', title: 'Mistral Nemo 12B (Ollama)', capabilities: { inference: true } },
-  { modelKey: 'codestral:22b', title: 'Codestral 22B (Ollama)', capabilities: { inference: true, tools: true } },
-  { modelKey: 'codeqwen:7b', title: 'CodeQwen 7B (Ollama)', capabilities: { inference: true, tools: true } },
-  { modelKey: 'deepseek-coder-v2:16b', title: 'DeepSeek Coder V2 16B (Ollama)', capabilities: { inference: true, tools: true } },
-  { modelKey: 'phi3.5:3.8b', title: 'Phi 3.5 3.8B (Ollama)', capabilities: { inference: true } },
-  { modelKey: 'gemma2:27b', title: 'Gemma 2 27B (Ollama)', capabilities: { inference: true } },
-  { modelKey: 'gemma2:9b', title: 'Gemma 2 9B (Ollama)', capabilities: { inference: true } },
-  { modelKey: 'llava:34b', title: 'LLaVA 34B (Ollama)', capabilities: { inference: true, image: true } },
-  { modelKey: 'llava:13b', title: 'LLaVA 13B (Ollama)', capabilities: { inference: true, image: true } },
-  { modelKey: 'llava:7b', title: 'LLaVA 7B (Ollama)', capabilities: { inference: true, image: true } },
-  { modelKey: 'bakllava:7b', title: 'BakLLaVA 7B (Ollama)', capabilities: { inference: true, image: true } },
-  { modelKey: 'dolphin-llama3:70b', title: 'Dolphin Llama 3 70B (Ollama)', capabilities: { inference: true } },
-  { modelKey: 'dolphin-llama3:8b', title: 'Dolphin Llama 3 8B (Ollama)', capabilities: { inference: true } },
-  { modelKey: 'nous-hermes2:34b', title: 'Nous Hermes 2 34B (Ollama)', capabilities: { inference: true } },
-  { modelKey: 'wizardlm2:7b', title: 'WizardLM 2 7B (Ollama)', capabilities: { inference: true } },
-  { modelKey: 'neural-chat:7b', title: 'Neural Chat 7B (Ollama)', capabilities: { inference: true } },
-  { modelKey: 'starling-lm:7b', title: 'Starling LM 7B (Ollama)', capabilities: { inference: true } },
-  { modelKey: 'openchat:7b', title: 'OpenChat 7B (Ollama)', capabilities: { inference: true } },
-  { modelKey: 'solar:10.7b', title: 'Solar 10.7B (Ollama)', capabilities: { inference: true } },
-  { modelKey: 'orca-mini:3b', title: 'Orca Mini 3B (Ollama)', capabilities: { inference: true } },
-  { modelKey: 'tinyllama:1.1b', title: 'TinyLlama 1.1B (Ollama)', capabilities: { inference: true } },
-  { modelKey: 'stable-code:3b', title: 'Stable Code 3B (Ollama)', capabilities: { inference: true } },
-  { modelKey: 'nomic-embed-text', title: 'Nomic Embed Text (Ollama)', capabilities: { embedding: true }, config: { embeddingDimensions: 768 } },
-  { modelKey: 'mxbai-embed-large', title: 'MxBai Embed Large (Ollama)', capabilities: { embedding: true }, config: { embeddingDimensions: 1024 } },
-  { modelKey: 'all-minilm:l6-v2', title: 'All MiniLM L6 v2 (Ollama)', capabilities: { embedding: true }, config: { embeddingDimensions: 384 } },
-
-  // Azure OpenAI Models
-  { modelKey: 'gpt-4o-azure', title: 'GPT-4o (Azure)', capabilities: { inference: true, tools: true, image: true } },
-  { modelKey: 'gpt-4-turbo-azure', title: 'GPT-4 Turbo (Azure)', capabilities: { inference: true, tools: true, image: true } },
-  { modelKey: 'gpt-35-turbo-azure', title: 'GPT-3.5 Turbo (Azure)', capabilities: { inference: true, tools: true } },
-
-  // Perplexity Models
-  { modelKey: 'llama-3.1-sonar-large-128k-online', title: 'Llama 3.1 Sonar Large Online', capabilities: { inference: true, tools: true } },
-  { modelKey: 'llama-3.1-sonar-small-128k-online', title: 'Llama 3.1 Sonar Small Online', capabilities: { inference: true, tools: true } },
-  { modelKey: 'llama-3.1-sonar-large-128k-chat', title: 'Llama 3.1 Sonar Large Chat', capabilities: { inference: true, tools: true } },
-  { modelKey: 'llama-3.1-sonar-small-128k-chat', title: 'Llama 3.1 Sonar Small Chat', capabilities: { inference: true, tools: true } },
-
-  // Voyage AI Models
-  { modelKey: 'voyage-3', title: 'Voyage 3', capabilities: { embedding: true }, config: { embeddingDimensions: 1024 } },
-  { modelKey: 'voyage-3-lite', title: 'Voyage 3 Lite', capabilities: { embedding: true }, config: { embeddingDimensions: 512 } },
-  { modelKey: 'voyage-large-2-instruct', title: 'Voyage Large 2 Instruct', capabilities: { embedding: true }, config: { embeddingDimensions: 1536 } },
-  { modelKey: 'voyage-law-2', title: 'Voyage Law 2', capabilities: { embedding: true }, config: { embeddingDimensions: 1024 } },
-  { modelKey: 'voyage-code-2', title: 'Voyage Code 2', capabilities: { embedding: true }, config: { embeddingDimensions: 1536 } },
-  { modelKey: 'voyage-large-2', title: 'Voyage Large 2', capabilities: { embedding: true }, config: { embeddingDimensions: 1536 } },
-  { modelKey: 'voyage-2', title: 'Voyage 2', capabilities: { embedding: true }, config: { embeddingDimensions: 1024 } },
-  { modelKey: 'voyage-lite-02-instruct', title: 'Voyage Lite 02 Instruct', capabilities: { embedding: true }, config: { embeddingDimensions: 1024 } },
-  { modelKey: 'voyage-multilingual-2', title: 'Voyage Multilingual 2', capabilities: { embedding: true }, config: { embeddingDimensions: 1024 } },
-  { modelKey: 'voyage-finance-2', title: 'Voyage Finance 2', capabilities: { embedding: true }, config: { embeddingDimensions: 1024 } },
-  { modelKey: 'rerank-2', title: 'Rerank 2', capabilities: { rerank: true } },
-  { modelKey: 'rerank-lite-1', title: 'Rerank Lite 1', capabilities: { rerank: true } }
 ];

--- a/shared/lib/modelTemplates.ts
+++ b/shared/lib/modelTemplates.ts
@@ -1,0 +1,199 @@
+// Model capabilities interface (duplicated here to avoid circular dependencies)
+export interface ModelCapabilities {
+  inference: boolean;
+  tools: boolean;
+  image: boolean;
+  imageGeneration: boolean;
+  video: boolean;
+  audio: boolean;
+  embedding: boolean;
+  rerank: boolean;
+}
+
+export interface ModelTemplate {
+  modelKey: string;
+  title: string;
+  capabilities: Partial<ModelCapabilities>;
+  config?: {
+    embeddingDimensions?: number;
+  };
+}
+
+export const DEFAULT_MODEL_TEMPLATES: ModelTemplate[] = [
+  // OpenAI Models
+  { modelKey: 'gpt-4o', title: 'GPT-4o', capabilities: { inference: true, tools: true, image: true } },
+  { modelKey: 'gpt-4o-mini', title: 'GPT-4o Mini', capabilities: { inference: true, tools: true, image: true } },
+  { modelKey: 'gpt-4-turbo', title: 'GPT-4 Turbo', capabilities: { inference: true, tools: true, image: true } },
+  { modelKey: 'gpt-4-turbo-preview', title: 'GPT-4 Turbo Preview', capabilities: { inference: true, tools: true } },
+  { modelKey: 'gpt-4', title: 'GPT-4', capabilities: { inference: true, tools: true } },
+  { modelKey: 'gpt-4-vision-preview', title: 'GPT-4 Vision Preview', capabilities: { inference: true, image: true } },
+  { modelKey: 'gpt-3.5-turbo', title: 'GPT-3.5 Turbo', capabilities: { inference: true, tools: true } },
+  { modelKey: 'gpt-3.5-turbo-instruct', title: 'GPT-3.5 Turbo Instruct', capabilities: { inference: true } },
+  { modelKey: 'text-embedding-3-large', title: 'Text Embedding 3 Large', capabilities: { embedding: true }, config: { embeddingDimensions: 3072 } },
+  { modelKey: 'text-embedding-3-small', title: 'Text Embedding 3 Small', capabilities: { embedding: true }, config: { embeddingDimensions: 1536 } },
+  { modelKey: 'text-embedding-ada-002', title: 'Text Embedding Ada 002', capabilities: { embedding: true }, config: { embeddingDimensions: 1536 } },
+  { modelKey: 'dall-e-3', title: 'DALL-E 3', capabilities: { imageGeneration: true } },
+  { modelKey: 'dall-e-2', title: 'DALL-E 2', capabilities: { imageGeneration: true } },
+  { modelKey: 'tts-1', title: 'TTS 1', capabilities: { audio: true } },
+  { modelKey: 'tts-1-hd', title: 'TTS 1 HD', capabilities: { audio: true } },
+
+  // Anthropic Models
+  { modelKey: 'claude-3-5-sonnet-20241022', title: 'Claude 3.5 Sonnet', capabilities: { inference: true, tools: true, image: true } },
+  { modelKey: 'claude-3-5-haiku-20241022', title: 'Claude 3.5 Haiku', capabilities: { inference: true, tools: true, image: true } },
+  { modelKey: 'claude-3-opus-20240229', title: 'Claude 3 Opus', capabilities: { inference: true, tools: true, image: true } },
+  { modelKey: 'claude-3-sonnet-20240229', title: 'Claude 3 Sonnet', capabilities: { inference: true, tools: true, image: true } },
+  { modelKey: 'claude-3-haiku-20240307', title: 'Claude 3 Haiku', capabilities: { inference: true, tools: true, image: true } },
+  { modelKey: 'claude-2.1', title: 'Claude 2.1', capabilities: { inference: true } },
+  { modelKey: 'claude-2.0', title: 'Claude 2.0', capabilities: { inference: true } },
+  { modelKey: 'claude-instant-1.2', title: 'Claude Instant 1.2', capabilities: { inference: true } },
+
+  // Google Models
+  { modelKey: 'gemini-1.5-pro', title: 'Gemini 1.5 Pro', capabilities: { inference: true, tools: true, image: true, video: true, audio: true } },
+  { modelKey: 'gemini-1.5-flash', title: 'Gemini 1.5 Flash', capabilities: { inference: true, tools: true, image: true, video: true, audio: true } },
+  { modelKey: 'gemini-pro', title: 'Gemini Pro', capabilities: { inference: true, tools: true } },
+  { modelKey: 'gemini-pro-vision', title: 'Gemini Pro Vision', capabilities: { inference: true, image: true } },
+  { modelKey: 'text-embedding-004', title: 'Text Embedding 004', capabilities: { embedding: true }, config: { embeddingDimensions: 768 } },
+  { modelKey: 'text-embedding-gecko', title: 'Text Embedding Gecko', capabilities: { embedding: true }, config: { embeddingDimensions: 768 } },
+
+  // Meta Llama Models
+  { modelKey: 'llama-3.1-405b-instruct', title: 'Llama 3.1 405B Instruct', capabilities: { inference: true, tools: true } },
+  { modelKey: 'llama-3.1-70b-instruct', title: 'Llama 3.1 70B Instruct', capabilities: { inference: true, tools: true } },
+  { modelKey: 'llama-3.1-8b-instruct', title: 'Llama 3.1 8B Instruct', capabilities: { inference: true, tools: true } },
+  { modelKey: 'llama-3-70b-instruct', title: 'Llama 3 70B Instruct', capabilities: { inference: true, tools: true } },
+  { modelKey: 'llama-3-8b-instruct', title: 'Llama 3 8B Instruct', capabilities: { inference: true, tools: true } },
+  { modelKey: 'llama-2-70b-chat', title: 'Llama 2 70B Chat', capabilities: { inference: true } },
+  { modelKey: 'llama-2-13b-chat', title: 'Llama 2 13B Chat', capabilities: { inference: true } },
+  { modelKey: 'llama-2-7b-chat', title: 'Llama 2 7B Chat', capabilities: { inference: true } },
+
+  // Mistral Models
+  { modelKey: 'mistral-large-2407', title: 'Mistral Large 2407', capabilities: { inference: true, tools: true } },
+  { modelKey: 'mistral-large-2402', title: 'Mistral Large 2402', capabilities: { inference: true, tools: true } },
+  { modelKey: 'mistral-medium', title: 'Mistral Medium', capabilities: { inference: true } },
+  { modelKey: 'mistral-small', title: 'Mistral Small', capabilities: { inference: true } },
+  { modelKey: 'mistral-tiny', title: 'Mistral Tiny', capabilities: { inference: true } },
+  { modelKey: 'mixtral-8x7b-instruct', title: 'Mixtral 8x7B Instruct', capabilities: { inference: true } },
+  { modelKey: 'mixtral-8x22b-instruct', title: 'Mixtral 8x22B Instruct', capabilities: { inference: true } },
+  { modelKey: 'mistral-7b-instruct', title: 'Mistral 7B Instruct', capabilities: { inference: true } },
+
+  // Qwen Models
+  { modelKey: 'qwen2.5-72b-instruct', title: 'Qwen 2.5 72B Instruct', capabilities: { inference: true, tools: true } },
+  { modelKey: 'qwen2.5-32b-instruct', title: 'Qwen 2.5 32B Instruct', capabilities: { inference: true, tools: true } },
+  { modelKey: 'qwen2.5-14b-instruct', title: 'Qwen 2.5 14B Instruct', capabilities: { inference: true, tools: true } },
+  { modelKey: 'qwen2.5-7b-instruct', title: 'Qwen 2.5 7B Instruct', capabilities: { inference: true, tools: true } },
+  { modelKey: 'qwen2-72b-instruct', title: 'Qwen 2 72B Instruct', capabilities: { inference: true, tools: true } },
+  { modelKey: 'qwen2-7b-instruct', title: 'Qwen 2 7B Instruct', capabilities: { inference: true, tools: true } },
+  { modelKey: 'qwen-vl-plus', title: 'Qwen VL Plus', capabilities: { inference: true, image: true } },
+  { modelKey: 'qwen-vl-max', title: 'Qwen VL Max', capabilities: { inference: true, image: true } },
+
+  // DeepSeek Models
+  { modelKey: 'deepseek-chat', title: 'DeepSeek Chat', capabilities: { inference: true, tools: true } },
+  { modelKey: 'deepseek-coder', title: 'DeepSeek Coder', capabilities: { inference: true, tools: true } },
+  { modelKey: 'deepseek-v2.5', title: 'DeepSeek V2.5', capabilities: { inference: true, tools: true } },
+
+  // Yi Models
+  { modelKey: 'yi-large', title: 'Yi Large', capabilities: { inference: true, tools: true } },
+  { modelKey: 'yi-medium', title: 'Yi Medium', capabilities: { inference: true } },
+  { modelKey: 'yi-vision', title: 'Yi Vision', capabilities: { inference: true, image: true } },
+
+  // Cohere Models
+  { modelKey: 'command-r-plus', title: 'Command R+', capabilities: { inference: true, tools: true } },
+  { modelKey: 'command-r', title: 'Command R', capabilities: { inference: true, tools: true } },
+  { modelKey: 'command', title: 'Command', capabilities: { inference: true } },
+  { modelKey: 'command-light', title: 'Command Light', capabilities: { inference: true } },
+  { modelKey: 'embed-english-v3.0', title: 'Embed English v3.0', capabilities: { embedding: true } },
+  { modelKey: 'embed-multilingual-v3.0', title: 'Embed Multilingual v3.0', capabilities: { embedding: true } },
+  { modelKey: 'rerank-english-v3.0', title: 'Rerank English v3.0', capabilities: { rerank: true } },
+  { modelKey: 'rerank-multilingual-v3.0', title: 'Rerank Multilingual v3.0', capabilities: { rerank: true } },
+
+  // Popular Ollama Models
+  { modelKey: 'llama3.1:70b', title: 'Llama 3.1 70B (Ollama)', capabilities: { inference: true, tools: true } },
+  { modelKey: 'llama3.1:8b', title: 'Llama 3.1 8B (Ollama)', capabilities: { inference: true, tools: true } },
+  { modelKey: 'qwen2.5:72b', title: 'Qwen 2.5 72B (Ollama)', capabilities: { inference: true, tools: true } },
+  { modelKey: 'qwen2.5:32b', title: 'Qwen 2.5 32B (Ollama)', capabilities: { inference: true, tools: true } },
+  { modelKey: 'qwen2.5:14b', title: 'Qwen 2.5 14B (Ollama)', capabilities: { inference: true, tools: true } },
+  { modelKey: 'qwen2.5:7b', title: 'Qwen 2.5 7B (Ollama)', capabilities: { inference: true, tools: true } },
+  { modelKey: 'mistral-nemo:12b', title: 'Mistral Nemo 12B (Ollama)', capabilities: { inference: true } },
+  { modelKey: 'codestral:22b', title: 'Codestral 22B (Ollama)', capabilities: { inference: true, tools: true } },
+  { modelKey: 'codeqwen:7b', title: 'CodeQwen 7B (Ollama)', capabilities: { inference: true, tools: true } },
+  { modelKey: 'deepseek-coder-v2:16b', title: 'DeepSeek Coder V2 16B (Ollama)', capabilities: { inference: true, tools: true } },
+  { modelKey: 'phi3.5:3.8b', title: 'Phi 3.5 3.8B (Ollama)', capabilities: { inference: true } },
+  { modelKey: 'gemma2:27b', title: 'Gemma 2 27B (Ollama)', capabilities: { inference: true } },
+  { modelKey: 'gemma2:9b', title: 'Gemma 2 9B (Ollama)', capabilities: { inference: true } },
+  { modelKey: 'llava:34b', title: 'LLaVA 34B (Ollama)', capabilities: { inference: true, image: true } },
+  { modelKey: 'llava:13b', title: 'LLaVA 13B (Ollama)', capabilities: { inference: true, image: true } },
+  { modelKey: 'llava:7b', title: 'LLaVA 7B (Ollama)', capabilities: { inference: true, image: true } },
+  { modelKey: 'bakllava:7b', title: 'BakLLaVA 7B (Ollama)', capabilities: { inference: true, image: true } },
+  { modelKey: 'dolphin-llama3:70b', title: 'Dolphin Llama 3 70B (Ollama)', capabilities: { inference: true } },
+  { modelKey: 'dolphin-llama3:8b', title: 'Dolphin Llama 3 8B (Ollama)', capabilities: { inference: true } },
+  { modelKey: 'nous-hermes2:34b', title: 'Nous Hermes 2 34B (Ollama)', capabilities: { inference: true } },
+  { modelKey: 'wizardlm2:7b', title: 'WizardLM 2 7B (Ollama)', capabilities: { inference: true } },
+  { modelKey: 'neural-chat:7b', title: 'Neural Chat 7B (Ollama)', capabilities: { inference: true } },
+  { modelKey: 'starling-lm:7b', title: 'Starling LM 7B (Ollama)', capabilities: { inference: true } },
+  { modelKey: 'openchat:7b', title: 'OpenChat 7B (Ollama)', capabilities: { inference: true } },
+  { modelKey: 'solar:10.7b', title: 'Solar 10.7B (Ollama)', capabilities: { inference: true } },
+  { modelKey: 'orca-mini:3b', title: 'Orca Mini 3B (Ollama)', capabilities: { inference: true } },
+  { modelKey: 'tinyllama:1.1b', title: 'TinyLlama 1.1B (Ollama)', capabilities: { inference: true } },
+  { modelKey: 'stable-code:3b', title: 'Stable Code 3B (Ollama)', capabilities: { inference: true } },
+  { modelKey: 'nomic-embed-text', title: 'Nomic Embed Text (Ollama)', capabilities: { embedding: true }, config: { embeddingDimensions: 768 } },
+  { modelKey: 'mxbai-embed-large', title: 'MxBai Embed Large (Ollama)', capabilities: { embedding: true }, config: { embeddingDimensions: 1024 } },
+  { modelKey: 'all-minilm:l6-v2', title: 'All MiniLM L6 v2 (Ollama)', capabilities: { embedding: true }, config: { embeddingDimensions: 384 } },
+
+  // Azure OpenAI Models
+  { modelKey: 'gpt-4o-azure', title: 'GPT-4o (Azure)', capabilities: { inference: true, tools: true, image: true } },
+  { modelKey: 'gpt-4-turbo-azure', title: 'GPT-4 Turbo (Azure)', capabilities: { inference: true, tools: true, image: true } },
+  { modelKey: 'gpt-35-turbo-azure', title: 'GPT-3.5 Turbo (Azure)', capabilities: { inference: true, tools: true } },
+
+  // Perplexity Models
+  { modelKey: 'llama-3.1-sonar-large-128k-online', title: 'Llama 3.1 Sonar Large Online', capabilities: { inference: true, tools: true } },
+  { modelKey: 'llama-3.1-sonar-small-128k-online', title: 'Llama 3.1 Sonar Small Online', capabilities: { inference: true, tools: true } },
+  { modelKey: 'llama-3.1-sonar-large-128k-chat', title: 'Llama 3.1 Sonar Large Chat', capabilities: { inference: true, tools: true } },
+  { modelKey: 'llama-3.1-sonar-small-128k-chat', title: 'Llama 3.1 Sonar Small Chat', capabilities: { inference: true, tools: true } },
+
+  // Voyage AI Models
+  { modelKey: 'voyage-3', title: 'Voyage 3', capabilities: { embedding: true }, config: { embeddingDimensions: 1024 } },
+  { modelKey: 'voyage-3-lite', title: 'Voyage 3 Lite', capabilities: { embedding: true }, config: { embeddingDimensions: 512 } },
+  { modelKey: 'voyage-large-2-instruct', title: 'Voyage Large 2 Instruct', capabilities: { embedding: true }, config: { embeddingDimensions: 1536 } },
+  { modelKey: 'voyage-law-2', title: 'Voyage Law 2', capabilities: { embedding: true }, config: { embeddingDimensions: 1024 } },
+  { modelKey: 'voyage-code-2', title: 'Voyage Code 2', capabilities: { embedding: true }, config: { embeddingDimensions: 1536 } },
+  { modelKey: 'voyage-large-2', title: 'Voyage Large 2', capabilities: { embedding: true }, config: { embeddingDimensions: 1536 } },
+  { modelKey: 'voyage-2', title: 'Voyage 2', capabilities: { embedding: true }, config: { embeddingDimensions: 1024 } },
+  { modelKey: 'voyage-lite-02-instruct', title: 'Voyage Lite 02 Instruct', capabilities: { embedding: true }, config: { embeddingDimensions: 1024 } },
+  { modelKey: 'voyage-multilingual-2', title: 'Voyage Multilingual 2', capabilities: { embedding: true }, config: { embeddingDimensions: 1024 } },
+  { modelKey: 'voyage-finance-2', title: 'Voyage Finance 2', capabilities: { embedding: true }, config: { embeddingDimensions: 1024 } },
+  { modelKey: 'rerank-2', title: 'Rerank 2', capabilities: { rerank: true } },
+  { modelKey: 'rerank-lite-1', title: 'Rerank Lite 1', capabilities: { rerank: true } }
+];
+
+// Helper function to infer model capabilities from model name
+export function inferModelCapabilities(modelName: string): ModelCapabilities {
+  const name = modelName.toLowerCase();
+  const template = DEFAULT_MODEL_TEMPLATES.find(t =>
+    name.includes(t.modelKey.toLowerCase()) ||
+    t.modelKey.toLowerCase().includes(name)
+  );
+
+  if (template) {
+    return {
+      inference: template.capabilities.inference || false,
+      tools: template.capabilities.tools || false,
+      image: template.capabilities.image || false,
+      imageGeneration: template.capabilities.imageGeneration || false,
+      video: template.capabilities.video || false,
+      audio: template.capabilities.audio || false,
+      embedding: template.capabilities.embedding || false,
+      rerank: template.capabilities.rerank || false
+    };
+  }
+
+  // Default: unknown models assumed to have inference capability
+  return {
+    inference: true,
+    tools: false,
+    image: false,
+    imageGeneration: false,
+    video: false,
+    audio: false,
+    embedding: false,
+    rerank: false
+  };
+}

--- a/test-docker/README.md
+++ b/test-docker/README.md
@@ -1,0 +1,63 @@
+# Docker Internal Network Test for Blinko AI Provider
+
+This directory contains test files to verify that the AI provider model fetching works correctly through Docker internal networks.
+
+## Problem Solved
+
+Previously, the `fetchProviderModels` function made HTTP requests directly from the browser, which meant Docker internal hostnames (like `http://ollama:11434`) were not accessible.
+
+This fix moves the model fetching logic to the backend server, allowing containers to communicate through Docker's internal network.
+
+## Test Setup
+
+### 1. Start the test environment
+
+```bash
+cd test-docker
+docker-compose -f docker-compose.test.yml up -d
+```
+
+### 2. Wait for services to be ready
+
+```bash
+docker-compose -f docker-compose.test.yml ps
+```
+
+All services should show as "healthy".
+
+### 3. Access Blinko
+
+Open http://localhost:1111 in your browser.
+
+### 4. Test the fix
+
+1. Go to Settings > AI Settings
+2. Add a new Provider:
+   - Provider Type: `OpenAI` or `Custom`
+   - Base URL: `http://mock-openai:8080/v1`
+   - API Key: `test-key` (any value works for the mock)
+3. Click "Fetch Models" button
+4. **Expected Result**: You should see 3 models listed:
+   - gpt-4o
+   - gpt-4o-mini
+   - gpt-3.5-turbo
+
+### 5. Verify in logs
+
+```bash
+docker logs mock-openai
+```
+
+You should see requests like:
+```
+2024-XX-XX... - GET /v1/models
+Returning model list...
+```
+
+This confirms the request came from the Blinko container (server-side), not from the browser.
+
+## Cleanup
+
+```bash
+docker-compose -f docker-compose.test.yml down -v
+```

--- a/test-docker/docker-compose.test.yml
+++ b/test-docker/docker-compose.test.yml
@@ -1,0 +1,61 @@
+version: '3.8'
+
+services:
+  # Mock OpenAI API for testing Docker internal network connectivity
+  mock-openai:
+    image: node:20-alpine
+    container_name: mock-openai
+    working_dir: /app
+    command: node server.js
+    volumes:
+      - ./mock-openai:/app
+    networks:
+      - blinko-test-network
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/models"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  # PostgreSQL database
+  postgres:
+    image: postgres:15-alpine
+    container_name: blinko-test-postgres
+    environment:
+      POSTGRES_USER: blinko
+      POSTGRES_PASSWORD: blinko
+      POSTGRES_DB: blinko
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - blinko-test-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U blinko"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # Blinko application
+  blinko:
+    image: blinkospace/blinko:latest
+    container_name: blinko-test
+    depends_on:
+      postgres:
+        condition: service_healthy
+      mock-openai:
+        condition: service_healthy
+    environment:
+      - DATABASE_URL=postgresql://blinko:blinko@postgres:5432/blinko
+      - NEXTAUTH_SECRET=test-secret-key-for-testing
+      - NEXTAUTH_URL=http://localhost:1111
+    ports:
+      - "1111:1111"
+    networks:
+      - blinko-test-network
+
+networks:
+  blinko-test-network:
+    driver: bridge
+
+volumes:
+  postgres_data:

--- a/test-docker/mock-openai/server.js
+++ b/test-docker/mock-openai/server.js
@@ -1,0 +1,41 @@
+const http = require('http');
+
+const models = {
+  data: [
+    { id: 'gpt-4o', object: 'model' },
+    { id: 'gpt-4o-mini', object: 'model' },
+    { id: 'gpt-3.5-turbo', object: 'model' }
+  ]
+};
+
+const server = http.createServer((req, res) => {
+  console.log(`${new Date().toISOString()} - ${req.method} ${req.url}`);
+
+  // Handle CORS
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type, api-key');
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(200);
+    res.end();
+    return;
+  }
+
+  if (req.url === '/v1/models' || req.url === '/models') {
+    console.log('Returning model list...');
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(models));
+  } else {
+    res.writeHead(404);
+    res.end('Not Found');
+  }
+});
+
+const PORT = 8080;
+server.listen(PORT, '0.0.0.0', () => {
+  console.log(`Mock OpenAI API running on port ${PORT}`);
+  console.log('Available endpoints:');
+  console.log('  GET /v1/models');
+  console.log('  GET /models');
+});


### PR DESCRIPTION
## Summary

- Move `fetchProviderModels` logic from frontend (browser) to backend (server) for Docker internal network access
- Frontend now calls backend tRPC API instead of making direct HTTP requests to AI providers
- Enables containers to communicate through Docker internal hostnames (e.g., `http://ollama:11434`)
- Supports existing HTTP proxy configuration

## Problem

Previously, the `fetchProviderModels` function made HTTP requests directly from the browser to fetch AI provider model lists. This meant Docker internal hostnames (like `http://ollama:11434`) were not accessible from the browser.

## Changes

| File | Description |
|------|-------------|
| `server/routerTrpc/ai.ts` | Add `fetchProviderModels` tRPC endpoint |
| `shared/lib/modelTemplates.ts` | New shared module for model templates |
| `app/src/store/aiSettingStore.tsx` | Simplify to call backend API |
| `app/src/components/BlinkoSettings/AiSetting/constants.tsx` | Re-export from shared module |
| `test-docker/` | Docker test environment with mock OpenAI API |

## Test plan

- [x] Start test environment: `cd test-docker && docker-compose -f docker-compose.test.yml up -d`
- [ ] Access Blinko at http://localhost:1111
- [ ] Add provider with Base URL: `http://mock-openai:8080/v1`
- [ ] Click "Fetch Models" - should return 3 mock models
- [ ] Verify request came from server by checking `docker logs mock-openai`

🤖 Generated with [Claude Code](https://claude.com/claude-code)