### PR TITLE
fixed  base url of gemini ai model provider

### DIFF
--- a/app/src/components/BlinkoSettings/AiSetting/constants.tsx
+++ b/app/src/components/BlinkoSettings/AiSetting/constants.tsx
@@ -78,7 +78,7 @@ export const PROVIDER_TEMPLATES = [
     value: 'google',
     label: 'Google AI',
     defaultName: 'Google AI',
-    defaultBaseURL: 'https://generativelanguage.googleapis.com',
+    defaultBaseURL: 'https://generativelanguage.googleapis.com/v1',
     website: 'https://ai.google.dev',
     docs: 'https://ai.google.dev/docs',
     icon: 'google',


### PR DESCRIPTION
this change fixes the Google AI Base URL, it was broken because google released the v1_beta api so the regular base url does not work anymore and i had errors connecting to gemini. 

with this fix i was able to fetch gemini models. 