### PR TITLE
fix german translation for sign-in-with-provider

### DIFF
--- a/app/public/locales/de/translation.json
+++ b/app/public/locales/de/translation.json
@@ -690,7 +690,7 @@
   "show-more": "Mehr anzeigen",
   "show-navigation-bar-on-mobile": "Navigationsleiste auf dem Handy ausblenden",
   "sign-in": "Anmelden",
-  "sign-in-with-provider": "Melden Sie sich mit {{ Anbieter }} an.",
+  "sign-in-with-provider": "Melden Sie sich mit {{ provider }} an.",
   "sign-up": "Registrieren",
   "site-url": "Blinko-Website-URL",
   "small-device-card-columns": "Spalten für kleine Bildschirme",


### PR DESCRIPTION
The german translation for the item sign-in-with-provider was wrong - the token "provider" seems to have been automatically translated to "Anbieter", but this is wrong as l10n lib will pass "provider" as interpolation parameter.

This should be fixed now.

