### PR TITLE
feat: add MiniMax as first-class LLM provider

### DIFF
--- a/app/src/components/BlinkoSettings/AiSetting/AIIcon.tsx
+++ b/app/src/components/BlinkoSettings/AiSetting/AIIcon.tsx
@@ -165,6 +165,11 @@ const MODEL_ICON_MAP: Array<{
     keywords: ['text2vec', 'gte-large', 'gte-base', 'gte-small', 'alibaba'],
     icon: Alibaba.Color
   },
+  // MiniMax models
+  {
+    keywords: ['minimax'],
+    icon: OpenAI
+  },
   // LangChain models
   {
     keywords: ['langchain', 'langchain-community'],

--- a/app/src/components/BlinkoSettings/AiSetting/constants.tsx
+++ b/app/src/components/BlinkoSettings/AiSetting/constants.tsx
@@ -136,5 +136,15 @@ export const PROVIDER_TEMPLATES = [
     docs: 'https://docs.voyageai.com',
     icon: 'voyageai',
     description: 'High-quality embedding models for retrieval and search'
+  },
+  {
+    value: 'minimax',
+    label: 'MiniMax',
+    defaultName: 'MiniMax',
+    defaultBaseURL: 'https://api.minimax.io/v1',
+    website: 'https://www.minimaxi.com',
+    docs: 'https://platform.minimaxi.com/document/introduction',
+    icon: 'minimax',
+    description: 'MiniMax M2.7, M2.5 and other MiniMax models'
   }
 ];

--- a/server/aiServer/providers/LLMProvider.ts
+++ b/server/aiServer/providers/LLMProvider.ts
@@ -76,6 +76,13 @@ export class LLMProvider extends BaseProvider {
           fetch: this.proxiedFetch
         }).languageModel(config.modelKey);
 
+      case 'minimax':
+        return createOpenAI({
+          apiKey: config.apiKey,
+          baseURL: config.baseURL || 'https://api.minimax.io/v1',
+          fetch: this.proxiedFetch
+        }).languageModel(config.modelKey);
+
       case 'custom':
       default:
         return createOpenAI({

--- a/server/aiServer/providers/__tests__/minimax-integration.test.ts
+++ b/server/aiServer/providers/__tests__/minimax-integration.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeAll } from 'bun:test';
+
+const MINIMAX_API_KEY = process.env.MINIMAX_API_KEY;
+const MINIMAX_BASE_URL = 'https://api.minimax.io/v1';
+const TIMEOUT = 30000;
+
+describe('MiniMax API Integration', () => {
+  const skip = !MINIMAX_API_KEY;
+
+  beforeAll(() => {
+    if (skip) {
+      console.log('Skipping MiniMax integration tests: MINIMAX_API_KEY not set');
+    }
+  });
+
+  it('should accept a valid API key for chat completions', async () => {
+    if (skip) return;
+
+    const response = await fetch(`${MINIMAX_BASE_URL}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${MINIMAX_API_KEY}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        model: 'MiniMax-M2.5-highspeed',
+        messages: [{ role: 'user', content: 'Reply with "ok"' }],
+        max_tokens: 5,
+        temperature: 0.1
+      })
+    });
+
+    expect(response.ok).toBe(true);
+    const data = await response.json() as any;
+    expect(data.choices).toBeDefined();
+    expect(data.choices[0].message.content).toBeTruthy();
+  }, TIMEOUT);
+
+  it('should complete a chat request with MiniMax-M2.5', async () => {
+    if (skip) return;
+
+    const response = await fetch(`${MINIMAX_BASE_URL}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${MINIMAX_API_KEY}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        model: 'MiniMax-M2.5',
+        messages: [{ role: 'user', content: 'Say "hello" and nothing else.' }],
+        max_tokens: 10,
+        temperature: 0.1
+      })
+    });
+
+    expect(response.ok).toBe(true);
+    const data = await response.json() as any;
+    expect(data.choices).toBeDefined();
+    expect(data.choices.length).toBeGreaterThan(0);
+    expect(data.choices[0].message.content).toBeTruthy();
+  }, TIMEOUT);
+
+  it('should support streaming with MiniMax API', async () => {
+    if (skip) return;
+
+    const response = await fetch(`${MINIMAX_BASE_URL}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${MINIMAX_API_KEY}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        model: 'MiniMax-M2.5',
+        messages: [{ role: 'user', content: 'Hi' }],
+        max_tokens: 5,
+        temperature: 0.1,
+        stream: true
+      })
+    });
+
+    expect(response.ok).toBe(true);
+    expect(response.headers.get('content-type')).toContain('text/event-stream');
+
+    const reader = response.body!.getReader();
+    const { value } = await reader.read();
+    expect(value).toBeTruthy();
+    reader.cancel();
+  }, TIMEOUT);
+});

--- a/server/aiServer/providers/__tests__/minimax-provider.test.ts
+++ b/server/aiServer/providers/__tests__/minimax-provider.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+
+// Mock the proxy module before importing LLMProvider
+mock.module('@server/lib/proxy', () => ({
+  fetchWithProxy: async () => fetch
+}));
+
+// Mock @ai-sdk/openai
+const mockLanguageModel = { modelId: 'MiniMax-M2.5' };
+const mockCreateOpenAI = mock((config: any) => ({
+  languageModel: mock((modelKey: string) => mockLanguageModel)
+}));
+
+mock.module('@ai-sdk/openai', () => ({
+  createOpenAI: mockCreateOpenAI
+}));
+
+// Mock other SDK modules to avoid import errors
+mock.module('@ai-sdk/anthropic', () => ({
+  createAnthropic: mock(() => ({ languageModel: mock(() => ({})) }))
+}));
+mock.module('@ai-sdk/google', () => ({
+  createGoogleGenerativeAI: mock(() => ({ languageModel: mock(() => ({})) }))
+}));
+mock.module('ollama-ai-provider', () => ({
+  createOllama: mock(() => ({ languageModel: mock(() => ({})) }))
+}));
+mock.module('@ai-sdk/deepseek', () => ({
+  createDeepSeek: mock(() => ({ languageModel: mock(() => ({})) }))
+}));
+mock.module('@openrouter/ai-sdk-provider', () => ({
+  createOpenRouter: mock(() => ({ languageModel: mock(() => ({})) }))
+}));
+mock.module('@ai-sdk/xai', () => ({
+  createXai: mock(() => ({ languageModel: mock(() => ({})) }))
+}));
+mock.module('@ai-sdk/azure', () => ({
+  createAzure: mock(() => ({ languageModel: mock(() => ({})) }))
+}));
+
+describe('MiniMax LLM Provider', () => {
+  beforeEach(() => {
+    mockCreateOpenAI.mockClear();
+  });
+
+  it('should handle minimax provider case', async () => {
+    const { LLMProvider } = await import('../LLMProvider');
+    const provider = new LLMProvider();
+
+    const result = await provider.getLanguageModel({
+      provider: 'minimax',
+      apiKey: 'test-api-key',
+      modelKey: 'MiniMax-M2.5'
+    });
+
+    expect(result).toBeDefined();
+    expect(mockCreateOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'test-api-key',
+        baseURL: 'https://api.minimax.io/v1'
+      })
+    );
+  });
+
+  it('should use default MiniMax base URL when not provided', async () => {
+    const { LLMProvider } = await import('../LLMProvider');
+    const provider = new LLMProvider();
+
+    await provider.getLanguageModel({
+      provider: 'minimax',
+      apiKey: 'test-key',
+      modelKey: 'MiniMax-M2.7'
+    });
+
+    expect(mockCreateOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL: 'https://api.minimax.io/v1'
+      })
+    );
+  });
+
+  it('should allow custom base URL override', async () => {
+    const { LLMProvider } = await import('../LLMProvider');
+    const provider = new LLMProvider();
+
+    await provider.getLanguageModel({
+      provider: 'minimax',
+      apiKey: 'test-key',
+      baseURL: 'https://custom.minimax.io/v1',
+      modelKey: 'MiniMax-M2.5'
+    });
+
+    expect(mockCreateOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL: 'https://custom.minimax.io/v1'
+      })
+    );
+  });
+
+  it('should be case-insensitive for provider name', async () => {
+    const { LLMProvider } = await import('../LLMProvider');
+    const provider = new LLMProvider();
+
+    await provider.getLanguageModel({
+      provider: 'MiniMax',
+      apiKey: 'test-key',
+      modelKey: 'MiniMax-M2.5'
+    });
+
+    expect(mockCreateOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL: 'https://api.minimax.io/v1'
+      })
+    );
+  });
+
+  it('should support all MiniMax model keys', async () => {
+    const { LLMProvider } = await import('../LLMProvider');
+    const provider = new LLMProvider();
+    const models = ['MiniMax-M2.7', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'];
+
+    for (const modelKey of models) {
+      mockCreateOpenAI.mockClear();
+      await provider.getLanguageModel({
+        provider: 'minimax',
+        apiKey: 'test-key',
+        modelKey
+      });
+      expect(mockCreateOpenAI).toHaveBeenCalled();
+    }
+  });
+
+  it('should pass proxiedFetch to createOpenAI', async () => {
+    const { LLMProvider } = await import('../LLMProvider');
+    const provider = new LLMProvider();
+
+    await provider.getLanguageModel({
+      provider: 'minimax',
+      apiKey: 'test-key',
+      modelKey: 'MiniMax-M2.5'
+    });
+
+    expect(mockCreateOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fetch: expect.any(Function)
+      })
+    );
+  });
+});

--- a/server/routerTrpc/ai.ts
+++ b/server/routerTrpc/ai.ts
@@ -694,6 +694,16 @@ export const aiRouter = router({
             break;
           }
 
+          case 'minimax': {
+            // Static list - MiniMax models with known capabilities
+            modelList = [
+              { id: 'MiniMax-M2.7', name: 'MiniMax M2.7', capabilities: inferModelCapabilities('MiniMax-M2.7') },
+              { id: 'MiniMax-M2.5', name: 'MiniMax M2.5', capabilities: inferModelCapabilities('MiniMax-M2.5') },
+              { id: 'MiniMax-M2.5-highspeed', name: 'MiniMax M2.5 Highspeed', capabilities: inferModelCapabilities('MiniMax-M2.5-highspeed') }
+            ];
+            break;
+          }
+
           default: {
             // Default: use OpenAI-compatible API format
             const endpoint = provider.baseURL;

--- a/shared/lib/__tests__/minimax-model-templates.test.ts
+++ b/shared/lib/__tests__/minimax-model-templates.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'bun:test';
+import { DEFAULT_MODEL_TEMPLATES, inferModelCapabilities } from '../modelTemplates';
+
+describe('MiniMax Model Templates', () => {
+  const minimaxModels = DEFAULT_MODEL_TEMPLATES.filter(t =>
+    t.modelKey.toLowerCase().startsWith('minimax')
+  );
+
+  it('should include MiniMax models in DEFAULT_MODEL_TEMPLATES', () => {
+    expect(minimaxModels.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('should have MiniMax-M2.7 model', () => {
+    const model = DEFAULT_MODEL_TEMPLATES.find(t => t.modelKey === 'MiniMax-M2.7');
+    expect(model).toBeDefined();
+    expect(model!.title).toBe('MiniMax M2.7');
+    expect(model!.capabilities.inference).toBe(true);
+    expect(model!.capabilities.tools).toBe(true);
+  });
+
+  it('should have MiniMax-M2.5 model', () => {
+    const model = DEFAULT_MODEL_TEMPLATES.find(t => t.modelKey === 'MiniMax-M2.5');
+    expect(model).toBeDefined();
+    expect(model!.title).toBe('MiniMax M2.5');
+    expect(model!.capabilities.inference).toBe(true);
+    expect(model!.capabilities.tools).toBe(true);
+  });
+
+  it('should have MiniMax-M2.5-highspeed model', () => {
+    const model = DEFAULT_MODEL_TEMPLATES.find(t => t.modelKey === 'MiniMax-M2.5-highspeed');
+    expect(model).toBeDefined();
+    expect(model!.title).toBe('MiniMax M2.5 Highspeed');
+    expect(model!.capabilities.inference).toBe(true);
+    expect(model!.capabilities.tools).toBe(true);
+  });
+
+  it('should infer MiniMax model capabilities correctly', () => {
+    const caps = inferModelCapabilities('MiniMax-M2.5');
+    expect(caps.inference).toBe(true);
+    expect(caps.tools).toBe(true);
+    expect(caps.embedding).toBe(false);
+    expect(caps.imageGeneration).toBe(false);
+  });
+
+  it('should infer capabilities for MiniMax-M2.7', () => {
+    const caps = inferModelCapabilities('MiniMax-M2.7');
+    expect(caps.inference).toBe(true);
+    expect(caps.tools).toBe(true);
+  });
+
+  it('should infer capabilities for MiniMax-M2.5-highspeed', () => {
+    const caps = inferModelCapabilities('MiniMax-M2.5-highspeed');
+    expect(caps.inference).toBe(true);
+    expect(caps.tools).toBe(true);
+  });
+
+  it('should have all MiniMax models with valid structure', () => {
+    for (const model of minimaxModels) {
+      expect(model.modelKey).toBeTruthy();
+      expect(model.title).toBeTruthy();
+      expect(model.capabilities).toBeDefined();
+      expect(typeof model.capabilities.inference).toBe('boolean');
+    }
+  });
+
+  it('should not have duplicate model keys among MiniMax models', () => {
+    const keys = minimaxModels.map(m => m.modelKey);
+    const uniqueKeys = new Set(keys);
+    expect(uniqueKeys.size).toBe(keys.length);
+  });
+});

--- a/shared/lib/modelTemplates.ts
+++ b/shared/lib/modelTemplates.ts
@@ -85,6 +85,11 @@ export const DEFAULT_MODEL_TEMPLATES: ModelTemplate[] = [
   { modelKey: 'qwen-vl-plus', title: 'Qwen VL Plus', capabilities: { inference: true, image: true } },
   { modelKey: 'qwen-vl-max', title: 'Qwen VL Max', capabilities: { inference: true, image: true } },
 
+  // MiniMax Models
+  { modelKey: 'MiniMax-M2.7', title: 'MiniMax M2.7', capabilities: { inference: true, tools: true } },
+  { modelKey: 'MiniMax-M2.5', title: 'MiniMax M2.5', capabilities: { inference: true, tools: true } },
+  { modelKey: 'MiniMax-M2.5-highspeed', title: 'MiniMax M2.5 Highspeed', capabilities: { inference: true, tools: true } },
+
   // DeepSeek Models
   { modelKey: 'deepseek-chat', title: 'DeepSeek Chat', capabilities: { inference: true, tools: true } },
   { modelKey: 'deepseek-coder', title: 'DeepSeek Coder', capabilities: { inference: true, tools: true } },


### PR DESCRIPTION
## Summary

Add [MiniMax](https://www.minimaxi.com) as a first-class LLM provider in Blinko, enabling users to leverage MiniMax's M2.7, M2.5, and M2.5-highspeed models for AI-powered note features.

MiniMax provides an OpenAI-compatible API at `https://api.minimax.io/v1`, making integration seamless using the existing `@ai-sdk/openai` package — no additional dependencies required.

## Changes

### Backend
- **`server/aiServer/providers/LLMProvider.ts`**: Add `minimax` case in the provider switch, using `createOpenAI` with MiniMax's default base URL
- **`server/routerTrpc/ai.ts`**: Add `minimax` case in `fetchProviderModels` with a static model list (M2.7, M2.5, M2.5-highspeed)

### Shared
- **`shared/lib/modelTemplates.ts`**: Add MiniMax M2.7, M2.5, and M2.5-highspeed to `DEFAULT_MODEL_TEMPLATES` with inference + tools capabilities

### Frontend
- **`app/src/components/BlinkoSettings/AiSetting/constants.tsx`**: Add MiniMax to `PROVIDER_TEMPLATES` with default base URL, docs link, and description
- **`app/src/components/BlinkoSettings/AiSetting/AIIcon.tsx`**: Add MiniMax keyword to `MODEL_ICON_MAP` for model icon matching

### Tests
- **9 unit tests** for model templates (model existence, capabilities, structure validation)
- **6 unit tests** for provider logic (case handling, default URL, custom URL, case-insensitivity)
- **3 integration tests** for MiniMax API connectivity (chat completions, streaming)

## How to Use

1. Go to Settings > AI Providers
2. Click "Add Provider" and select **MiniMax**
3. Enter your MiniMax API key (get one at https://platform.minimaxi.com)
4. Select a model (M2.7, M2.5, or M2.5-highspeed)
5. Set as your main model and start using AI features

## Test Plan

- [x] Unit tests pass (`bun test shared/lib/__tests__/minimax-model-templates.test.ts`)
- [x] Integration tests pass (`bun test server/aiServer/providers/__tests__/minimax-integration.test.ts`)
- [ ] Verify MiniMax appears in provider selection UI
- [ ] Verify model auto-discovery works for MiniMax provider
- [ ] Verify chat completions work with MiniMax models
