### PR TITLE
fix: sanitize filenames to prevent upload 500 errors (#1138)

### DIFF
--- a/server/__tests__/sanitizeUploadFileName.test.ts
+++ b/server/__tests__/sanitizeUploadFileName.test.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect } from 'bun:test';
+import { sanitizeUploadFileName } from '../lib/files';
+
+describe('sanitizeUploadFileName', () => {
+  test('passes through simple ASCII filenames unchanged', () => {
+    expect(sanitizeUploadFileName('my_document')).toBe('my_document');
+    expect(sanitizeUploadFileName('report-2024')).toBe('report-2024');
+  });
+
+  test('preserves Chinese characters', () => {
+    expect(sanitizeUploadFileName('挽救计划')).toBe('挽救计划');
+  });
+
+  test('replaces reserved filesystem characters with underscores', () => {
+    expect(sanitizeUploadFileName('file<name>test')).toBe('file_name_test');
+    expect(sanitizeUploadFileName('file:name')).toBe('file_name');
+    expect(sanitizeUploadFileName('file"name')).toBe('file_name');
+    expect(sanitizeUploadFileName('file|name')).toBe('file_name');
+    expect(sanitizeUploadFileName('file?name')).toBe('file_name');
+    expect(sanitizeUploadFileName('file*name')).toBe('file_name');
+  });
+
+  test('replaces whitespace with underscores', () => {
+    expect(sanitizeUploadFileName('hello world')).toBe('hello_world');
+    expect(sanitizeUploadFileName('multiple   spaces')).toBe('multiple_spaces');
+    // tab is whitespace, replaced with underscore
+    expect(sanitizeUploadFileName('tab\there')).toBe('tab_here');
+  });
+
+  test('removes control characters', () => {
+    expect(sanitizeUploadFileName('file\x00name')).toBe('filename');
+    expect(sanitizeUploadFileName('file\x1fname')).toBe('filename');
+    expect(sanitizeUploadFileName('file\x7fname')).toBe('filename');
+    expect(sanitizeUploadFileName('file\x80name')).toBe('filename');
+    expect(sanitizeUploadFileName('file\x9fname')).toBe('filename');
+  });
+
+  test('removes leading/trailing dots and spaces', () => {
+    expect(sanitizeUploadFileName('.hidden')).toBe('hidden');
+    expect(sanitizeUploadFileName('...dots')).toBe('dots');
+    expect(sanitizeUploadFileName('trailing.')).toBe('trailing');
+  });
+
+  test('truncates filenames longer than 200 characters', () => {
+    const longName = 'a'.repeat(250);
+    const result = sanitizeUploadFileName(longName);
+    expect(result.length).toBe(200);
+  });
+
+  test('returns fallback for empty or whitespace-only names', () => {
+    expect(sanitizeUploadFileName('')).toBe('unnamed_file');
+    expect(sanitizeUploadFileName('   ')).toBe('unnamed_file');
+    expect(sanitizeUploadFileName('...')).toBe('unnamed_file');
+  });
+
+  test('handles the exact bug report filename (issue #1138)', () => {
+    // This is the filename from the bug report that caused 500 error
+    const bugFilename = '挽救计划(《火星救援》作者安迪·威尔全新力作,出版后连续16周雄踞亚马逊科幻畅销榜第一名科技宅男+跨星系好友联袂上演太空大救援,硬核工程风+..._(z-library.sk,_1lib.sk,_z-lib.sk)';
+    const result = sanitizeUploadFileName(bugFilename);
+
+    // Should not throw
+    expect(result).toBeTruthy();
+    // Should preserve Chinese characters and parentheses
+    expect(result).toContain('挽救计划');
+    expect(result).toContain('(');
+    // Should not contain reserved chars
+    expect(result).not.toMatch(/[<>:"/\\|?*]/);
+    // Should be within length limit
+    expect(result.length).toBeLessThanOrEqual(200);
+  });
+
+  test('handles filenames with only reserved characters', () => {
+    expect(sanitizeUploadFileName('<>:"/\\|?*')).toBe('unnamed_file');
+  });
+
+  test('handles mixed unicode and special characters', () => {
+    const result = sanitizeUploadFileName('日本語テスト<file>');
+    expect(result).toBe('日本語テスト_file');
+  });
+});

--- a/server/lib/files.ts
+++ b/server/lib/files.ts
@@ -12,6 +12,38 @@ import { createWriteStream } from "fs";
 import pathIsInside from 'path-is-inside';
 import sanitizeFilename from 'sanitize-filename';
 
+/**
+ * Sanitize a filename for safe filesystem storage.
+ * Removes control characters, reserved characters, truncates to safe length,
+ * and replaces whitespace with underscores.
+ */
+export function sanitizeUploadFileName(name: string): string {
+  let sanitized = name
+    // Replace whitespace (including tabs) with underscores BEFORE removing control chars
+    .replace(/\s+/g, '_')
+    // Remove control characters (0x00-0x1f, 0x7f, 0x80-0x9f)
+    .replace(/[\x00-\x1f\x7f\x80-\x9f]/g, '')
+    // Replace reserved filesystem characters
+    .replace(/[<>:"/\\|?*]/g, '_')
+    // Collapse multiple consecutive underscores
+    .replace(/_+/g, '_')
+    // Remove leading/trailing dots, spaces, and underscores
+    .replace(/^[.\s_]+|[.\s_]+$/g, '');
+
+  // Truncate to 200 characters to stay well under filesystem limits (255)
+  // while leaving room for timestamp suffix and extension
+  if (sanitized.length > 200) {
+    sanitized = sanitized.substring(0, 200);
+  }
+
+  // Fallback if the name is empty after sanitization
+  if (!sanitized) {
+    sanitized = 'unnamed_file';
+  }
+
+  return sanitized;
+}
+
 export class FileService {
   /**
    * Validates and sanitizes a file path to prevent path traversal attacks
@@ -169,7 +201,8 @@ export class FileService {
     buffer: Buffer, originalName: string, type: string, withOutAttachment?: boolean, accountId: number, metadata?: any
   }) {
     const extension = path.extname(originalName);
-    const baseName = path.basename(originalName, extension);
+    const rawBaseName = path.basename(originalName, extension);
+    const baseName = sanitizeUploadFileName(rawBaseName);
     const timestamp = Date.now();
     const config = await getGlobalConfig({ useAdmin: true });
 
@@ -324,7 +357,8 @@ export class FileService {
     }) {
     const config = await getGlobalConfig({ useAdmin: true });
     const extension = path.extname(originalName);
-    const baseName = path.basename(originalName, extension);
+    const rawBaseName = path.basename(originalName, extension);
+    const baseName = sanitizeUploadFileName(rawBaseName);
     const timestamp = Date.now();
     const timestampedFileName = `${baseName}_${timestamp}${extension}`;
 

--- a/server/routerExpress/file/upload.ts
+++ b/server/routerExpress/file/upload.ts
@@ -112,7 +112,16 @@ router.post('/', async (req, res) => {
       if (fieldname === 'file') {
         const passThrough = new PassThrough();
         let fileSize = 0;
-        const decodedFilename = Buffer.from(info.filename, 'binary').toString('utf-8');
+        let decodedFilename: string;
+        try {
+          decodedFilename = Buffer.from(info.filename, 'binary').toString('utf-8');
+        } catch {
+          decodedFilename = info.filename;
+        }
+        // Fallback if decoding produced an empty or invalid string
+        if (!decodedFilename || decodedFilename.trim() === '') {
+          decodedFilename = info.filename || `upload_${Date.now()}`;
+        }
         
         stream.on('data', (chunk) => {
           fileSize += chunk.length;


### PR DESCRIPTION
## Summary
- Fixes #1138
- Root cause: Filenames with special characters (Chinese brackets, long names, control chars) were passed unsanitized to `validateAndResolvePath`, which compared the `sanitizeFilename()` output against the original — any difference threw "contains dangerous characters", causing a 500 error
- Fix: Added `sanitizeUploadFileName()` that cleans filenames **before** path construction — removes control chars, replaces reserved chars, truncates to 200 chars, and provides fallback for empty names
- Also hardened the `Buffer.from(filename, 'binary').toString('utf-8')` decoding in the upload handler with try/catch fallback

## Test Evidence
- [x] 11 unit tests added: `server/__tests__/sanitizeUploadFileName.test.ts`
- [x] Covers: Chinese characters, reserved chars, control chars, long names (>200 chars), whitespace, empty names, and the **exact bug report filename**
- [x] All tests pass: `bun test server/__tests__/sanitizeUploadFileName.test.ts`

## Test plan
- [ ] Upload a file with Chinese characters and special symbols in the name (e.g., parentheses, brackets)
- [ ] Upload a file with a very long filename (100+ characters)
- [ ] Upload a file with a simple name (regression check)
- [ ] Verify the uploaded file is accessible and the attachment metadata is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code) via /bug-patrol