### PR TITLE
fix: read account id from jwt sub in scheduled task tool

### DIFF
--- a/server/aiServer/tools/scheduledTask.ts
+++ b/server/aiServer/tools/scheduledTask.ts
@@ -40,9 +40,13 @@ The prompt is what the AI will execute when the task runs. For example:
       if (!user) {
         return { success: false, error: 'Authentication failed' };
       }
-      userId = Number(user.id);
+      userId = Number((user as any).id ?? (user as any).sub);
     } else {
       return { success: false, error: 'No authentication provided' };
+    }
+
+    if (!Number.isFinite(userId)) {
+      return { success: false, error: 'Invalid user id in token' };
     }
 
     try {


### PR DESCRIPTION
Fixes #1052

The scheduled task tool was reading user.id from verifyToken, but the JWT payload provides the user id in sub. This now falls back to sub and rejects invalid numeric ids before creating the task.

Greetings, saschabuehrle