### PR TITLE
fix: typo in English translation for user password reset

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -65,7 +65,7 @@
   "sign-in": "Sign in",
   "nickname": "Nickname",
   "change-user-info": "Change User Info",
-  "rest-user-password": "Rest User Password",
+  "rest-user-password": "Reset User Password",
   "confirm-password": "Confirm Password",
   "confirm-your-password": "Confirm your password",
   "enter-your-username": "Enter your username",


### PR DESCRIPTION
Fixes a typo in the English translation for user password reset (Rest -> Reset):
<img width="466" height="375" alt="image" src="https://github.com/user-attachments/assets/75f69729-d75c-4ef5-9396-0f95917f6200" />
