### PR TITLE
fix: resolve folder rename ENOENT and deletion failures in Resources

### DIFF
--- a/server/routerTrpc/attachment.ts
+++ b/server/routerTrpc/attachment.ts
@@ -297,7 +297,10 @@ export const attachmentsRouter = router({
                 `${baseUrl}${newName.split(',').join('/')}`
               );
 
-              await FileService.moveFile(oldPath, newPath);
+              // Skip file system operation for folder placeholder entries
+              if (attachment.name !== '.folder' && attachment.type !== 'folder') {
+                await FileService.moveFile(oldPath, newPath);
+              }
 
               await tx.attachments.update({
                 where: { id: attachment.id },
@@ -411,24 +414,35 @@ export const attachmentsRouter = router({
         if (isFolder && folderPath) {
           const attachments = await tx.attachments.findMany({
             where: {
-              note: {
-                accountId: Number(ctx.id)
-              },
+              OR: [
+                {
+                  note: {
+                    accountId: Number(ctx.id)
+                  }
+                },
+                {
+                  accountId: Number(ctx.id)
+                }
+              ],
               perfixPath: {
                 startsWith: folderPath
               }
             }
           });
 
-          if (attachments.length === 0) {
-            return { success: true, message: 'Folder deleted successfully' };
-          }
-
           try {
             for (const attachment of attachments) {
-              await FileService.deleteFile(attachment.path);
+              // Skip file system deletion for folder placeholder entries
+              if (attachment.name !== '.folder' && attachment.type !== 'folder') {
+                await FileService.deleteFile(attachment.path);
+              }
             }
-            return { success: true, message: 'Folder and its contents deleted successfully' };
+            await tx.attachments.deleteMany({
+              where: {
+                id: { in: attachments.map(a => a.id) }
+              }
+            });
+            return { success: true, message: 'Folder deleted successfully' };
           } catch (error) {
             throw new Error(`Failed to delete folder: ${error.message}`);
           }
@@ -456,6 +470,9 @@ export const attachmentsRouter = router({
 
         try {
           await FileService.deleteFile(attachment.path);
+          await tx.attachments.delete({
+            where: { id: attachment.id }
+          });
           return {
             success: true,
             message: 'File deleted successfully'


### PR DESCRIPTION
Fixes #1128

## Problem

Folders in the Resources section could not be renamed or deleted properly:

1. **Rename throws ENOENT**: When renaming a folder, the code tried to call `FileService.moveFile()` on the `.folder` placeholder attachment. This placeholder entry is DB-only — no physical file is created on the filesystem when a folder is created — so `moveFile` throws `ENOENT: no such file or directory`.

2. **Delete shows success but folder remains**: The delete query only searched for attachments linked to notes (`note.accountId == ctx.id`), but the `.folder` placeholder was created with a direct `accountId` and no note link. For an empty folder, no attachments were found, so the code returned early with `success: true` without deleting the DB record — leaving the folder visible in the UI.

3. **DB records not cleaned up after deletion**: Even when files were found and deleted from disk, the corresponding `attachments` DB records were never removed.

## Solution

- **Rename**: Skip `FileService.moveFile()` for `.folder` placeholder attachments (identified by `name === '.folder'` or `type === 'folder'`). Only update the DB record with the new path.
- **Delete query**: Extended the folder delete query to use `OR [note.accountId, accountId]` so it correctly finds both note-linked attachments and standalone placeholders (like the `.folder` entry).
- **DB cleanup**: Added `tx.attachments.deleteMany()` after physical file deletion to remove all attachment records for a deleted folder. Also added `tx.attachments.delete()` to the single-file delete path.
- **Skip placeholder in delete**: Skip `FileService.deleteFile()` for `.folder` placeholder attachments to avoid ENOENT when deleting empty folders.

## Testing

1. Go to Resources tab
2. Create a new folder (e.g. "testfolder")
3. **Rename test**: Right-click → Rename → enter new name → confirm. The folder should rename without any ENOENT error.
4. **Delete test**: Right-click → Delete → confirm. The folder should disappear from the UI immediately.
5. **Non-empty folder**: Upload a file into a folder, then delete the folder. Both the file and folder record should be removed.